### PR TITLE
#10 Go back one char

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/snippet"
@@ -21,15 +22,21 @@ var newCmd = &cobra.Command{
 }
 
 func scan(message string) (string, error) {
-	fmt.Print(message)
-	scanner := bufio.NewScanner(os.Stdin)
-	if !scanner.Scan() {
+
+	oldState, err := terminal.MakeRaw(0)
+	if err != nil {
+		return "", err
+	}
+	defer terminal.Restore(0, oldState)
+
+	t := terminal.NewTerminal(os.Stdin, message)
+	s, err := t.ReadLine()
+
+	if s == "" {
 		return "", errors.New("canceled")
 	}
-	if scanner.Err() != nil {
-		return "", scanner.Err()
-	}
-	return scanner.Text(), nil
+
+	return s, err
 }
 
 func new(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -30,6 +30,9 @@ func scan(message string) (string, error) {
 	if runtime.GOOS == "windows" {
 		fmt.Print(message)
 		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() || scanner.Text() == "" {
+			return "", errors.New("canceled")
+		}
 		if scanner.Err() != nil {
 			return "", scanner.Err()
 		}
@@ -43,14 +46,14 @@ func scan(message string) (string, error) {
 
 		t := terminal.NewTerminal(os.Stdin, message)
 		s, err = t.ReadLine()
+		if s == "" {
+			return "", errors.New("canceled")
+		}
 		if err != nil {
 			return "", err
 		}
 	}
 
-	if s == "" {
-		return "", errors.New("canceled")
-	}
 	return s, nil
 }
 


### PR DESCRIPTION
This is for #10.

It is a trial implementation to allow the fields to be able to move cursor. The cursor seems to be okay on Windows, and without the platform check the bottom half will break Windows.

Also I have fixed some other issues:
- When use "prev" as described in the README.md the description field could be empty.
- When on Windows the cancelled check does not work.

I haven't tested on OS X as I don't have a Mac, tested on Linux and Windows.