### PR TITLE
Added pet to AUR for easy install on archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ You can homebrew on OS X.
 $ brew install knqyf263/pet/pet
 ```
 
+## Archlinux
+A package is available in [AUR](https://aur.archlinux.org/packages/pet-git/).
+```
+$ yaourt -S pet-git
+```
+
 ## Build
 
 ```


### PR DESCRIPTION
Hi, i have added your package on the AUR, it's a script that use go-get to build and install Pet.

You can update the Readme to inform people if you want.