### PR TITLE
long param views

### DIFF
--- a/dialog/view.go
+++ b/dialog/view.go
@@ -49,7 +49,7 @@ func GenerateParamsLayout(params map[string]string, command string) {
 	idx := 0
 	for k, v := range params {
 		generateView(g, k, v, []int{maxX / 10, (maxY / 4) + (idx+1)*layoutStep,
-			maxX/10 + 20, (maxY / 4) + 2 + (idx+1)*layoutStep}, true)
+			(maxX / 2) + (maxX / 3), (maxY / 4) + 2 + (idx+1)*layoutStep}, true)
 		idx++
 	}
 


### PR DESCRIPTION
Ok, messed with git a little bit, sorry.
Take this ugly long param views, the real problem is I don't know how to make CUI rerender param views dynamically if there are more than 8 on a screen =)
You can use GenerateParamsLayout as g.SetManagerFunc(GenerateParamsLayout), though it must not have params in the signature, so CUI can be rerendered, but it's work only the first time and not the second.