### PR TITLE
parse params only with no spaces around

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -29,7 +29,7 @@ func insertParams(command string, params map[string]string) string {
 
 // SearchForParams returns variables from a command
 func SearchForParams(lines []string) map[string]string {
-	re := "<(.+?)>"
+	re := "<[\\S](.+?)[\\S]>"
 	if len(lines) == 1 {
 		r, _ := regexp.Compile(re)
 


### PR DESCRIPTION
to avoid bug with command like that
sed -e '1,3d' < t.txt >> t2.txt