### PR TITLE
Silence usage when an error occurs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,9 +37,10 @@ var configFile string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "pet",
-	Short: "Simple command-line snippet manager.",
-	Long:  `pet - Simple command-line snippet manager.`,
+	Use:          "pet",
+	Short:        "Simple command-line snippet manager.",
+	Long:         `pet - Simple command-line snippet manager.`,
+	SilenceUsage: true,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
FEATURE REQUEST:

This behavior is too noisy. should be silenced

```console
$ pet new
Command> hoge
Description> ^C
Error: canceled
Usage:
  pet new COMMAND [flags]

Flags:
  -t, --tag   Display tag prompt (delimiter: space)

Global Flags:
      --config string   config file (default is $HOME/.config/pet/config.toml)
      --debug           debug mode

canceled
```

Run the following after patching this PR

```console
Command> hoge
Description> ^C
Error: canceled
canceled
```

it's smart, i think. Perhaps it is better to add the option of `cobra.Command. SilenceErrors` c.f: https://godoc.org/github.com/spf13/cobra#Command

Displaying `Error: canceled` and `canceled` may be redundant

BTW, this tool is so cool, thanks.