### PR TITLE
Add function to automatically synchronize snippet file

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"io/ioutil"
+
 	"github.com/knqyf263/pet/config"
 	"github.com/spf13/cobra"
 )
@@ -17,11 +19,32 @@ func edit(cmd *cobra.Command, args []string) (err error) {
 	editor := config.Conf.General.Editor
 	snippetFile := config.Conf.General.SnippetFile
 
+	// file content before editing
+	before := fileContent(snippetFile)
+
 	err = editFile(editor, snippetFile)
-	if err == nil && config.Conf.Gist.AutoSync {
+	if err != nil {
+		return
+	}
+
+	// file content after editing
+	after := fileContent(snippetFile)
+
+	// return if same file content
+	if before == after {
+		return nil
+	}
+
+	if config.Conf.Gist.AutoSync {
 		return autoSync(snippetFile)
 	}
-	return err
+
+	return nil
+}
+
+func fileContent(fname string) string {
+	data, _ := ioutil.ReadFile(fname)
+	return string(data)
 }
 
 func init() {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -17,7 +17,11 @@ func edit(cmd *cobra.Command, args []string) (err error) {
 	editor := config.Conf.General.Editor
 	snippetFile := config.Conf.General.SnippetFile
 
-	return editFile(editor, snippetFile)
+	err = editFile(editor, snippetFile)
+	if err == nil && config.Conf.Gist.AutoSync {
+		return autoSync(snippetFile)
+	}
+	return err
 }
 
 func init() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,15 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/BurntSushi/toml"
-	"github.com/google/go-github/github"
 	"github.com/knqyf263/pet/config"
-	"github.com/knqyf263/pet/snippet"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 )
 
 // syncCmd represents the sync command
@@ -28,86 +23,9 @@ Write access_token in config file (pet configure).
 		`)
 	}
 
-	if config.Flag.Upload {
-		return upload()
-	}
-	return download()
-}
-
-func githubClient() *github.Client {
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: config.Conf.Gist.AccessToken},
-	)
-	tc := oauth2.NewClient(oauth2.NoContext, ts)
-	client := github.NewClient(tc)
-	return client
-}
-
-func upload() (err error) {
-	ctx := context.Background()
-
-	var snippets snippet.Snippets
-	if err := snippets.Load(); err != nil {
-		return err
-	}
-
-	body, err := snippets.ToString()
-	if err != nil {
-		return err
-	}
-
-	client := githubClient()
-	gist := github.Gist{
-		Description: github.String("description"),
-		Public:      github.Bool(config.Conf.Gist.Public),
-		Files: map[github.GistFilename]github.GistFile{
-			github.GistFilename(config.Conf.Gist.FileName): github.GistFile{
-				Content: github.String(body),
-			},
-		},
-	}
-
-	gistID := config.Conf.Gist.GistID
-	if gistID == "" {
-		var retGist *github.Gist
-		retGist, _, err = client.Gists.Create(ctx, &gist)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Gist ID: %s\n", retGist.GetID())
-	} else {
-		_, _, err = client.Gists.Edit(ctx, gistID, &gist)
-		if err != nil {
-			return err
-		}
-	}
-	fmt.Println("Upload success")
-	return nil
-}
-
-func download() error {
-	if config.Conf.Gist.GistID == "" {
-		return fmt.Errorf("Gist ID is empty")
-	}
-	ctx := context.Background()
-	client := githubClient()
-	resGist, _, err := client.Gists.Get(ctx, config.Conf.Gist.GistID)
-	if err != nil {
-		return fmt.Errorf("Failed to download gist: %v", err)
-	}
-	content := resGist.Files[github.GistFilename(config.Conf.Gist.FileName)].Content
-
-	var snippets snippet.Snippets
-	toml.Decode(*content, &snippets)
-	if err := snippets.Save(); err != nil {
-		return err
-	}
-	fmt.Println("Download success")
-	return nil
+	return autoSync(config.Conf.General.SnippetFile)
 }
 
 func init() {
 	RootCmd.AddCommand(syncCmd)
-	syncCmd.Flags().BoolVarP(&config.Flag.Upload, "upload", "u", false,
-		`Upload snippets to gist`)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,19 +2,84 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
+	"github.com/google/go-github/github"
 	"github.com/knqyf263/pet/config"
 	"github.com/knqyf263/pet/snippet"
 
 	"github.com/knqyf263/pet/dialog"
 )
+
+func autoSync(file string) error {
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s.Start()
+	defer s.Stop()
+
+	fi, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+
+	client := githubClient()
+	gist, _, err := client.Gists.Get(context.Background(), config.Conf.Gist.GistID)
+	if err != nil {
+		return err
+	}
+	local := fi.ModTime().UTC()
+	remote := gist.UpdatedAt.UTC()
+
+	switch {
+	case local.After(remote):
+		return upload()
+	case remote.After(local):
+		return update(gist)
+	default:
+		return nil
+	}
+}
+
+func update(gist *github.Gist) error {
+	var (
+		content     = ""
+		snippetFile = config.Conf.General.SnippetFile
+		filename    = config.Conf.Gist.FileName
+	)
+	for _, file := range gist.Files {
+		if *file.Filename == filename {
+			content = *file.Content
+		}
+	}
+	if content == "" {
+		return fmt.Errorf("%s is empty", filename)
+	}
+
+	var snippets snippet.Snippets
+	if err := snippets.Load(); err != nil {
+		return err
+	}
+	body, err := snippets.ToString()
+	if err != nil {
+		return err
+	}
+	if content == body {
+		// no need to update
+		return nil
+	}
+
+	fmt.Println("Download success")
+	return ioutil.WriteFile(snippetFile, []byte(content), os.ModePerm)
+}
 
 func editFile(command, file string) error {
 	command += " " + file

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type GistConfig struct {
 	AccessToken string `toml:"access_token"`
 	GistID      string `toml:"gist_id"`
 	Public      bool   `toml:"public"`
+	AutoSync    bool   `toml:"auto_sync"`
 }
 
 // Flag is global flag variable

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,6 @@ type FlagConfig struct {
 	Debug     bool
 	Query     string
 	Delimiter string
-	Upload    bool
 	OneLine   bool
 	Color     bool
 	Tag       bool


### PR DESCRIPTION
### Feature request

If you enable the `auto_sync` option, the snippet file is synchronized at the moment you exit the editor with `:wq` etc.

Actually, I am making a tool called "`b4b4r07/gist`" like your pet. This auto-sync is implemented by my tool, and its porting.

### Question

pet has `sync` command, and it explicitly uses `upload` and `download`. If you don't mind, I would like to improve this usability.

In that case (if you answered OK,) this PR is WIP