### PR TITLE
Improve snippet parameter parsing

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -29,7 +29,7 @@ func insertParams(command string, params map[string]string) string {
 
 // SearchForParams returns variables from a command
 func SearchForParams(lines []string) map[string]string {
-	re := `<([\S].+?[\S])>`
+	re := `<([^\s=>]+(?:=(?:\\\\|\\>|[^>\\])*)?)>`
 	if len(lines) == 1 {
 		r, _ := regexp.Compile(re)
 


### PR DESCRIPTION
Before, the regular expression matched almost everything between two
angle brackets, leading to false positive matches, e.g. when using
bash's process substitution.

The new regular expression eliminates these matches by enforcing more
strict rules for the parameter name and its optional default value. The
name must not contain white space characters, the equals sign (=) or the
greater-than character (>). The default value can include any character,
with the exception of the greater-than character which needs to be
escaped by a leading backslash like this '\\>'.

Before:
![](https://user-images.githubusercontent.com/1039174/26950642-8d033bf6-4c9e-11e7-8f28-f3c5982c1e42.png)
After:
![](https://user-images.githubusercontent.com/1039174/26950679-aafb04a4-4c9e-11e7-9f8f-7b5143f7cd99.png)