### PR TITLE
Add pet-bin AUR package in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,14 @@ $ brew install knqyf263/pet/pet
 ```
 
 ## Archlinux
-A package is available in [AUR](https://aur.archlinux.org/packages/pet-git/).
+Two packages are available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+You can install the package [from source](https://aur.archlinux.org/packages/pet-git):
 ```
 $ yaourt -S pet-git
+```
+Or [from the binary](https://aur.archlinux.org/packages/pet-bin):
+```
+$ yaourt -S pet-bin
 ```
 
 ## Build


### PR DESCRIPTION
There weren't a AUR package for installing from the binary available here: https://github.com/knqyf263/pet/releases so I created one.