### PR TITLE
Fix Makefile for `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ depup:
 build: main.go dep
 	go build -o pet $<
 
-install: main.go deps
+install: main.go dep
 	go install
 
 lint:


### PR DESCRIPTION
I tried installing pet while reading [README.md#Build](https://github.com/knqyf263/pet#build), but I cannot execute `make install`

```sh
$ make install
make: *** No rule to make target `deps', needed by `install'.  Stop.
```

I thought it was typo, so I fixed it.