### PR TITLE
Allow use private GitLab repositories.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type GistConfig struct {
 type GitLabConfig struct {
 	FileName    string `toml:"file_name"`
 	AccessToken string `toml:"access_token"`
+	Url         string `toml:"url"`
 	ID          string `toml:"id"`
 	Visibility  string `toml:"visibility"`
 	AutoSync    bool   `toml:"auto_sync"`

--- a/sync/gitlab.go
+++ b/sync/gitlab.go
@@ -26,9 +26,14 @@ Go https://gitlab.com/profile/personal_access_tokens and create access_token.
 Write access_token in config file (pet configure).
 		`)
 	}
+
 	client := GitLabClient{
 		Client: gitlab.NewClient(nil, config.Conf.GitLab.AccessToken),
 		ID:     0,
+	}
+
+	if config.Conf.GitLab.Url != "" {
+		client.Client.SetBaseURL(config.Conf.GitLab.Url)
 	}
 
 	if config.Conf.GitLab.ID == "" {


### PR DESCRIPTION
The url parameter is added to be able to choose the url to be used as a GitLab repository.

Not work with self-signed certificates or certs signed by unknown authority.