### PR TITLE
Bash prev function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ So I made it possible to register snippets with description and search them easi
 - [Main features](#main-features)
 - [Examples](#examples)
     - [Register the previous command easily](#register-the-previous-command-easily)
-        - [bash/zsh](#bashzsh)
+        - [bash](#bash-prev-function)
+        - [zsh](#zsh-prev-function)
         - [fish](#fish)
     - [Select snippets at the current line (like C-r)](#select-snippets-at-the-current-line-like-c-r)
         - [bash](#bash)
@@ -79,7 +80,7 @@ Some examples are shown below.
 ## Register the previous command easily
 By adding the following config to `.bashrc` or `.zshrc`, you can easily register the previous command.
 
-### bash
+### bash prev function
 
 ```
 function prev() {
@@ -88,7 +89,7 @@ function prev() {
 }
 ```
 
-### zsh
+### zsh prev function
 
 ```
 $ cat .zshrc

--- a/README.md
+++ b/README.md
@@ -77,9 +77,18 @@ So I made it possible to register snippets with description and search them easi
 Some examples are shown below.
 
 ## Register the previous command easily
-
-### bash/zsh
 By adding the following config to `.bashrc` or `.zshrc`, you can easily register the previous command.
+
+### bash
+
+```
+function prev() {
+  PREV=$(echo `history | tail -n2 | head -n1` | sed 's/[0-9]* //')
+  sh -c "pet new `printf %q "$PREV"`"
+}
+```
+
+### zsh
 
 ```
 $ cat .zshrc


### PR DESCRIPTION
I was installing pet on my Ubuntu laptop and tried to configure the `prev` function in my `.bashrc` file, as I thought it was a great idea.

However, when trying it out, I got this:

![before](https://user-images.githubusercontent.com/11257760/46443871-523ba680-c767-11e8-8b75-874c5a2482ce.png)

I made a quick change to get it working and thought it might be useful for others to have it available as a point of reference in your readme.

Screen shot of it working as expected after my changes:

![after](https://user-images.githubusercontent.com/11257760/46443921-9333bb00-c767-11e8-8a94-da41b8b2e9dd.png)

Thanks for such an awesome tool!