### PR TITLE
Fix printing newly created gist ID

### DIFF
--- a/sync/gist.go
+++ b/sync/gist.go
@@ -87,7 +87,7 @@ func (g GistClient) UploadSnippet(content string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Gist ID: %d\n", gistID)
+		fmt.Printf("Gist ID: %s\n", *gistID)
 	} else {
 		if err := g.updateGist(context.Background(), gist); err != nil {
 			return errors.Wrap(err, "Failed to update gist")


### PR DESCRIPTION
Gist ID is returned from createGist() as pointer to string, but it was printed as an number instead of string, giving user a memory address instead of gist id. This pull request fixes this issue by printing string dereferenced from returned pointer.