### PR TITLE
Add config option to sort snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Run `pet configure`
   column = 40                     # column size for list command
   selectcmd = "fzf"               # selector command for edit command (fzf or peco)
   backend = "gist"                # specify backend service to sync snippets (gist or gitlab, default: gist)
+  sortby  = "description"         # specify how snippets get sorted (recency (default), -recency, description, -description, command, -command, output, -output)
 
 [Gist]
   file_name = "pet-snippet.toml"  # specify gist file name

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type GeneralConfig struct {
 	Column      int    `toml:"column"`
 	SelectCmd   string `toml:"selectcmd"`
 	Backend     string `toml:"backend"`
+	SortBy      string `toml:"sortby"`
 }
 
 // GistConfig is a struct of config for Gist

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/BurntSushi/toml"
 	"github.com/knqyf263/pet/config"
@@ -29,6 +30,7 @@ func (snippets *Snippets) Load() error {
 	if _, err := toml.DecodeFile(snippetFile, snippets); err != nil {
 		return fmt.Errorf("Failed to load snippet file. %v", err)
 	}
+	snippets.Order()
 	return nil
 }
 
@@ -52,3 +54,52 @@ func (snippets *Snippets) ToString() (string, error) {
 	}
 	return buffer.String(), nil
 }
+
+// Order snippets regarding SortBy option defined in config toml
+// Prefix "-" reverses the order, default is "recency", "+<expressions>" is the same as "<expression>"
+func (snippets *Snippets) Order() {
+	sortBy := config.Conf.General.SortBy
+	switch {
+	case sortBy == "command" || sortBy == "+command":
+		sort.Sort(ByCommand(snippets.Snippets))
+	case sortBy == "-command":
+		sort.Sort(sort.Reverse(ByCommand(snippets.Snippets)))
+
+	case sortBy == "description" || sortBy == "+description":
+		sort.Sort(ByDescription(snippets.Snippets))
+	case sortBy == "-description":
+		sort.Sort(sort.Reverse(ByDescription(snippets.Snippets)))
+
+	case sortBy == "output" || sortBy == "+output":
+		sort.Sort(ByOutput(snippets.Snippets))
+	case sortBy == "-output":
+		sort.Sort(sort.Reverse(ByOutput(snippets.Snippets)))
+
+	case sortBy == "-recency":
+		snippets.reverse()
+	}
+}
+
+func (snippets *Snippets) reverse() {
+	for i, j := 0, len(snippets.Snippets)-1; i < j; i, j = i+1, j-1 {
+		snippets.Snippets[i], snippets.Snippets[j] = snippets.Snippets[j], snippets.Snippets[i]
+	}
+}
+
+type ByCommand []SnippetInfo
+
+func (a ByCommand) Len() int           { return len(a) }
+func (a ByCommand) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByCommand) Less(i, j int) bool { return a[i].Command > a[j].Command }
+
+type ByDescription []SnippetInfo
+
+func (a ByDescription) Len() int           { return len(a) }
+func (a ByDescription) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByDescription) Less(i, j int) bool { return a[i].Description > a[j].Description }
+
+type ByOutput []SnippetInfo
+
+func (a ByOutput) Len() int           { return len(a) }
+func (a ByOutput) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByOutput) Less(i, j int) bool { return a[i].Output > a[j].Output }


### PR DESCRIPTION
Adds the option `sortby` to the General section of the config which allows to sort snippets using diffrent criteria: (recency (default), -recency, description, -description, command, -command, output, -output)