### PR TITLE
Set focus on first param field

### DIFF
--- a/dialog/view.go
+++ b/dialog/view.go
@@ -56,7 +56,10 @@ func GenerateParamsLayout(params map[string]string, command string) {
 	initKeybindings(g)
 
 	curView = 0
-	g.SetCurrentView(views[0])
+	if idx > 0 {
+		curView = 1
+	}
+	g.SetCurrentView(views[curView])
 
 	if err := g.MainLoop(); err != nil && err != gocui.ErrQuit {
 		log.Panicln(err)


### PR DESCRIPTION
Set the focus on the first param field instead of the command field.

Just a minor UX tweak to reduce one tab keystroke every time a param is needed