### PR TITLE
Fix incorrect version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
   goarm:
   - "6"
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  ldflags: -s -w -X github.com/knqyf263/pet/cmd.version={{.Version}}
 archive:
   format: tar.gz
   name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,11 +29,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	version = "0.3.2"
+var (
+	configFile string
+	version    = "dev"
 )
-
-var configFile string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{


### PR DESCRIPTION
Hi, thanks for this awesome tool! I found out that the version in the release binary does not match the release, i.e. binary from release 0.3.4 shows that it is version 0.3.2:

```
$ curl -L  https://github.com/knqyf263/pet/releases/download/v0.3.4/pet_0.3.4_darwin_amd64.tar.gz | tar xv
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   619    0   619    0     0    952      0 --:--:-- --:--:-- --:--:--   952
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0x LICENSE
x README.md
x misc/completions/zsh/_pet
100 3553k  100 3553k    0     0  1238k      0  0:00:02  0:00:02 --:--:-- 2118k

$ ./pet version
pet version 0.3.2
```

Currently the version is hardcoded in https://github.com/knqyf263/pet/blob/f0a1e2c334b360acf60c3c2aeffcbfbe8f28cfab/cmd/root.go#L33

However, I think we can automate this by making use of goreleaser which is what this PR is proposing.
Also remove `main.commit={{.Commit}} -X main.date={{.Date}}` as we are not using it.

Please let me know what you think. Thanks!