### PR TITLE
add multiline command support

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ func list(cmd *cobra.Command, args []string) error {
 			description := runewidth.FillRight(runewidth.Truncate(snippet.Description, col, "..."), col)
 			command := runewidth.Truncate(snippet.Command, 100-4-col, "...")
 			// make sure multiline command printed as oneline
-			command = strings.ReplaceAll(command, "\n", "\\n")
+			command = strings.Replace(command, "\n", "\\n", -1)
 			fmt.Fprintf(color.Output, "%s : %s\n",
 				color.GreenString(description), color.YellowString(command))
 		} else {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -38,13 +38,26 @@ func list(cmd *cobra.Command, args []string) error {
 		if config.Flag.OneLine {
 			description := runewidth.FillRight(runewidth.Truncate(snippet.Description, col, "..."), col)
 			command := runewidth.Truncate(snippet.Command, 100-4-col, "...")
+			// make sure multiline command printed as oneline
+			command = strings.ReplaceAll(command, "\n", "\\n")
 			fmt.Fprintf(color.Output, "%s : %s\n",
 				color.GreenString(description), color.YellowString(command))
 		} else {
 			fmt.Fprintf(color.Output, "%12s %s\n",
 				color.GreenString("Description:"), snippet.Description)
-			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.YellowString("    Command:"), snippet.Command)
+			if strings.Contains(snippet.Command, "\n") {
+				lines := strings.Split(snippet.Command, "\n")
+				firstLine, restLines := lines[0], lines[1:]
+				fmt.Fprintf(color.Output, "%12s %s\n",
+					color.YellowString("    Command:"), firstLine)
+				for _, line := range restLines {
+					fmt.Fprintf(color.Output, "%12s %s\n",
+						" ", line)
+				}
+			} else {
+				fmt.Fprintf(color.Output, "%12s %s\n",
+					color.YellowString("    Command:"), snippet.Command)
+			}
 			if snippet.Tag != nil {
 				tag := strings.Join(snippet.Tag, " ")
 				fmt.Fprintf(color.Output, "%12s %s\n",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -42,7 +42,11 @@ func filter(options []string) (commands []string, err error) {
 	snippetTexts := map[string]snippet.SnippetInfo{}
 	var text string
 	for _, s := range snippets.Snippets {
-		t := fmt.Sprintf("[%s]: %s", s.Description, s.Command)
+		command := s.Command
+		if strings.ContainsAny(command, "\n") {
+			command = strings.ReplaceAll(command, "\n", "\\n")
+		}
+		t := fmt.Sprintf("[%s]: %s", s.Description, command)
 
 		tags := ""
 		for _, tag := range s.Tag {
@@ -53,7 +57,7 @@ func filter(options []string) (commands []string, err error) {
 		snippetTexts[t] = s
 		if config.Flag.Color {
 			t = fmt.Sprintf("[%s]: %s",
-				color.RedString(s.Description), s.Command)
+				color.RedString(s.Description), command)
 		}
 		text += t + "\n"
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -44,7 +44,7 @@ func filter(options []string) (commands []string, err error) {
 	for _, s := range snippets.Snippets {
 		command := s.Command
 		if strings.ContainsAny(command, "\n") {
-			command = strings.ReplaceAll(command, "\n", "\\n")
+			command = strings.Replace(command, "\n", "\\n", -1)
 		}
 		t := fmt.Sprintf("[%s]: %s", s.Description, command)
 


### PR DESCRIPTION
For a multiline command like this:
```shell
pet new 'if [ 1 == 1];then
    echo 233
fi' 
```
It was impossible for a multiline command to be selected from fzf, because each line of this multiline command was regarded as an independent command, just like:
![2019-06-12_09-54](https://user-images.githubusercontent.com/21141423/59318001-11356200-8cf8-11e9-9e80-242fcc536d55.png)
So I replaced the line separator with its literal representation before the snippets text was piped to fzf as a workaround, so now `pet exec` would be like this:
![image](https://user-images.githubusercontent.com/21141423/59318255-ef88aa80-8cf8-11e9-8cf8-504d8d974104.png)
I also modified `cmd/list.go` for better looking when listing multiline commands.
Before:
![image](https://user-images.githubusercontent.com/21141423/59318372-68880200-8cf9-11e9-88b5-161dc66befba.png)
After:
![image](https://user-images.githubusercontent.com/21141423/59318395-80f81c80-8cf9-11e9-937b-bc6835e0c9d5.png)

