### PR TITLE
Close #107 by properly handle last newline

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -70,7 +70,7 @@ func filter(options []string) (commands []string, err error) {
 		return nil, nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
 
 	params := dialog.SearchForParams(lines)
 	if params != nil {


### PR DESCRIPTION
It seems that TrimSpace was intended to remove the last newline.  However, using strings.TrimSpace also removes other whitespace charactes which causes the selected snippet not be able to be presented on screen.