### PR TITLE
Check if file size is 0 for #105

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -36,7 +36,7 @@ func AutoSync(file string) error {
 	}
 
 	fi, err := os.Stat(file)
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || fi.Size() == 0 {
 		return download(snippet.Content)
 	} else if err != nil {
 		return errors.Wrap(err, "Failed to get a FileInfo")


### PR DESCRIPTION
Fixes https://github.com/knqyf263/pet/issues/105 in a way that if the empty toml file is created upon first start it will not overwrite the existing gist with an empty file, but it would rather download it.