### PR TITLE
Support multi line

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +69,8 @@ type FlagConfig struct {
 func (cfg *Config) Load(file string) error {
 	_, err := os.Stat(file)
 	if err == nil {
-		_, err := toml.DecodeFile(file, cfg)
+		f, err := os.ReadFile(file)
+		err = toml.Unmarshal(f, cfg)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -55,13 +55,14 @@ var Flag FlagConfig
 
 // FlagConfig is a struct of flag
 type FlagConfig struct {
-	Debug     bool
-	Query     string
-	Command   bool
-	Delimiter string
-	OneLine   bool
-	Color     bool
-	Tag       bool
+	Debug            bool
+	Query            string
+	Command          bool
+	Delimiter        string
+	OneLine          bool
+	Color            bool
+	Tag              bool
+	MultiLineSnippet bool
 }
 
 // Load loads a config toml

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/knqyf263/pet
 
+go 1.16
+
 require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
@@ -14,6 +16,7 @@ require (
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.2
 	github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 // indirect
+	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5 h1:osZyZB7J4kE1
 github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
@@ -24,6 +25,8 @@ github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 h1:LspjgiiJb/DZ7UVtzoAdjGX29eb6VQwFWGgdC6fguB4=
 github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/knqyf263/pet/config"
 )
 
@@ -27,9 +27,11 @@ func (snippets *Snippets) Load() error {
 	if _, err := os.Stat(snippetFile); os.IsNotExist(err) {
 		return nil
 	}
-	if _, err := toml.DecodeFile(snippetFile, snippets); err != nil {
+	f, err := os.ReadFile(snippetFile)
+	if err != nil {
 		return fmt.Errorf("Failed to load snippet file. %v", err)
 	}
+	toml.Unmarshal(f, snippets)
 	snippets.Order()
 	return nil
 }

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -16,7 +16,7 @@ type Snippets struct {
 
 type SnippetInfo struct {
 	Description string   `toml:"description"`
-	Command     string   `toml:"command"`
+	Command     string   `toml:"command" multiline:"true"`
 	Tag         []string `toml:"tag"`
 	Output      string   `toml:"output"`
 }


### PR DESCRIPTION
*Issue #116*

*Description of changes:*

Add a `--multiline` flag in `pet new` subcommand.

```bash
$ pet new --multiline
Command> for i in 1 2 3;
.......> do
.......>     echo "$i"
.......> done
.......> 
.......> 
Description> test multi line new 3
```
- Double enter to finish command entering.
- Don't trim space surround commands.

Entry below will generated:
```toml
[[snippets]]
  description = "test multi line new 3"
  command = "for i in 1 2 3;\ndo\n\techo \"$i\"\ndone"  # I want to support triple quote raw string, but github.com/BurntSushi/toml don't support this feature, and it's unmaintained.
  output = ""
```

Tested pet search, exec, it works well on my test toml:
```toml
[[snippets]]
  description = "test run multiline"
  command = "for i in 1 2 3;\ndo\n\techo \"$i\"\ndone"
  output = ""

[[snippets]]
  description = "test run multiline 2"
  command = """for i in 1 2 3;
do
	echo \"$i\"
done
"""
  output = ""
```

Test result: 
```bash
$ pet search --query multi1
for i in 1 2 3;
do
        echo "$i"
done

$ pet search --query multi2
for i in 1 2 3;
do
        echo "$i"
done

$ pet exec --query multi1
1
2
3

$ pet exec --query multi2
1
2
3
```

## roadmap
- [x] Basic multiline support.
  - [x] `pet new`
  - [x] `pet exec` and `pet search`
- [x] generate triple quote raw string while `pet new -m`.
  - [x] Replace unmaintained dependency [BurntSushi/toml](github.com/BurntSushi/toml)

I also want to:
- Enhance tag support of `pet`, make something like list all tag or filter by tag.
- Enhance `pet edit`, so we can fuzzy find an entry and jump to it right we enter the editor.

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
