### PR TITLE
Enhance parameter selection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +69,8 @@ type FlagConfig struct {
 func (cfg *Config) Load(file string) error {
 	_, err := os.Stat(file)
 	if err == nil {
-		_, err := toml.DecodeFile(file, cfg)
+		f, err := os.ReadFile(file)
+		err = toml.Unmarshal(f, cfg)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -55,13 +55,14 @@ var Flag FlagConfig
 
 // FlagConfig is a struct of flag
 type FlagConfig struct {
-	Debug     bool
-	Query     string
-	Command   bool
-	Delimiter string
-	OneLine   bool
-	Color     bool
-	Tag       bool
+	Debug            bool
+	Query            string
+	Command          bool
+	Delimiter        string
+	OneLine          bool
+	Color            bool
+	Tag              bool
+	MultiLineSnippet bool
 }
 
 // Load loads a config toml

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -43,7 +43,7 @@ func generateParameterView(g *gocui.Gui, desc string, fill string, coords []int,
 		fmt.Fprint(v, fill)
 	}
 	view, _ := g.View(desc)
-	splitted := strings.Split(desc[1:len(desc)-2], "=")
+	splitted := strings.Split(desc[1:len(desc)-1], "=")
 	view.Title = splitted[0]
 	view.Wrap = false
 	view.Autoscroll = true

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -19,7 +19,30 @@ func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable
 		fmt.Fprint(v, fill)
 	}
 	view, _ := g.View(desc)
-	// TODO: A stabler solution is making a class of params
+	view.Title = desc
+	view.Wrap = false
+	view.Autoscroll = true
+	view.Editable = editable
+
+	views = append(views, desc)
+	idxView++
+
+	return nil
+}
+
+
+// TODO: A stabler solution is making a class of params
+func generateParameterView(g *gocui.Gui, desc string, fill string, coords []int, editable bool) error {
+	if StringInSlice(desc, views) {
+		return nil
+	}
+	if v, err := g.SetView(desc, coords[0], coords[1], coords[2], coords[3]); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		fmt.Fprint(v, fill)
+	}
+	view, _ := g.View(desc)
 	splitted := strings.Split(desc[1:len(desc)-2], "=")
 	view.Title = splitted[0]
 	view.Wrap = false
@@ -31,6 +54,7 @@ func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable
 
 	return nil
 }
+
 
 // GenerateParamsLayout generates CUI to receive params
 func GenerateParamsLayout(params map[string]string, command string) {
@@ -51,7 +75,7 @@ func GenerateParamsLayout(params map[string]string, command string) {
 		command, []int{maxX / 10, maxY / 10, (maxX / 2) + (maxX / 3), maxY/10 + 5}, false)
 	idx := 0
 	for k, v := range params {
-		generateView(g, k, v, []int{maxX / 10, (maxY / 4) + (idx+1)*layoutStep,
+		generateParameterView(g, k, v, []int{maxX / 10, (maxY / 4) + (idx+1)*layoutStep,
 			maxX/10 + 20, (maxY / 4) + 2 + (idx+1)*layoutStep}, true)
 		idx++
 	}

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -88,6 +88,11 @@ func initKeybindings(g *gocui.Gui) error {
 	if err := g.SetKeybinding("", gocui.KeyEnter, gocui.ModNone, evaluateParams); err != nil {
 		return err
 	}
+
+	if err := g.SetKeybinding("", gocui.KeyCtrlU, gocui.ModNone, clear); err != nil {
+		return err
+	}
+
 	if err := g.SetKeybinding("", gocui.KeyTab, gocui.ModNone,
 		func(g *gocui.Gui, v *gocui.View) error {
 			return nextView(g)
@@ -98,6 +103,12 @@ func initKeybindings(g *gocui.Gui) error {
 }
 
 func layout(g *gocui.Gui) error {
+	return nil
+}
+
+
+func clear(_ *gocui.Gui, v *gocui.View) error {
+	v.Clear()
 	return nil
 }
 

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/jroimartin/gocui"
 )
@@ -18,7 +19,9 @@ func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable
 		fmt.Fprint(v, fill)
 	}
 	view, _ := g.View(desc)
-	view.Title = desc
+	// TODO: A stabler solution is making a class of params
+	splitted := strings.Split(desc[1:len(desc)-2], "=")
+	view.Title = splitted[0]
 	view.Wrap = false
 	view.Autoscroll = true
 	view.Editable = editable

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/knqyf263/pet
 
+go 1.16
+
 require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
@@ -14,6 +16,7 @@ require (
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.2
 	github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 // indirect
+	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5 h1:osZyZB7J4kE1
 github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
@@ -24,6 +25,8 @@ github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 h1:LspjgiiJb/DZ7UVtzoAdjGX29eb6VQwFWGgdC6fguB4=
 github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/knqyf263/pet/config"
 )
 
@@ -27,9 +27,11 @@ func (snippets *Snippets) Load() error {
 	if _, err := os.Stat(snippetFile); os.IsNotExist(err) {
 		return nil
 	}
-	if _, err := toml.DecodeFile(snippetFile, snippets); err != nil {
+	f, err := os.ReadFile(snippetFile)
+	if err != nil {
 		return fmt.Errorf("Failed to load snippet file. %v", err)
 	}
+	toml.Unmarshal(f, snippets)
 	snippets.Order()
 	return nil
 }

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -16,7 +16,7 @@ type Snippets struct {
 
 type SnippetInfo struct {
 	Description string   `toml:"description"`
-	Command     string   `toml:"command"`
+	Command     string   `toml:"command" multiline:"true"`
 	Tag         []string `toml:"tag"`
 	Output      string   `toml:"output"`
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a keyboard shortcut ^U to clear selected parameter in parameter expanding view. Useful when you set a default value, but don't like it. You can quickly kill it and replace with things you like.

Also simplified title of each parameter view.

For example, a parameter like `<Name=DefaultValue>`
- Old title: `Name=DefaultValue`
- New title: `Name`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
