### PR TITLE
feat(exec) ignore ctrl-c when exec

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
@@ -37,6 +39,8 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 	if config.Flag.Command {
 		fmt.Printf("%s: %s\n", color.YellowString("Command"), command)
 	}
+
+	signal.Ignore(syscall.SIGINT)
 	return run(command, os.Stdin, os.Stdout)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/knqyf263/pet
 
+go 1.16
+
 require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5


### PR DESCRIPTION
#170

*Description of changes:*

ignore ctrl-c in `pet exec`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
