### PR TITLE
feat filter tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ $ pet search
 [ping]: ping 8.8.8.8 #network #google
 ```
 
+You can exec snipet with filtering the tag
+
+```
+$ pet exec -t google
+
+[ping]: ping 8.8.8.8 #network #google
+```
+
 ## Sync
 ### Gist
 You must obtain access token.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -26,7 +26,7 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 		options = append(options, fmt.Sprintf("--query %s", flag.Query))
 	}
 
-	commands, err := filter(options)
+	commands, err := filter(options, flag.FilterTag)
 	if err != nil {
 		return err
 	}
@@ -46,6 +46,8 @@ func init() {
 		`Enable colorized output (only fzf)`)
 	execCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
 		`Initial value for query`)
+	execCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
+		`Filter tag`)
 	execCmd.Flags().BoolVarP(&config.Flag.Command, "command", "c", false,
 		`Show the command with the plain text before executing`)
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -26,7 +26,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 	if flag.Query != "" {
 		options = append(options, fmt.Sprintf("--query %s", flag.Query))
 	}
-	commands, err := filter(options)
+	commands, err := filter(options, flag.FilterTag)
 	if err != nil {
 		return err
 	}
@@ -44,6 +44,8 @@ func init() {
 		`Enable colorized output (only fzf)`)
 	searchCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
 		`Initial value for query`)
+	searchCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
+		`Filter tag`)
 	searchCmd.Flags().StringVarP(&config.Flag.Delimiter, "delimiter", "d", "; ",
 		`Use delim as the command delimiter character`)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -33,10 +33,22 @@ func run(command string, r io.Reader, w io.Writer) error {
 	return cmd.Run()
 }
 
-func filter(options []string) (commands []string, err error) {
+func filter(options []string, tag string) (commands []string, err error) {
 	var snippets snippet.Snippets
 	if err := snippets.Load(); err != nil {
 		return commands, fmt.Errorf("Load snippet failed: %v", err)
+	}
+
+	if 0 < len(tag) {
+		var filteredSnipets snippet.Snippets
+		for _, snipet := range snippets.Snippets {
+			for _, t := range snipet.Tag {
+				if tag == t {
+					filteredSnipets.Snippets = append(filteredSnipets.Snippets, snipet)
+				}
+			}
+		}
+		snippets = filteredSnipets
 	}
 
 	snippetTexts := map[string]snippet.SnippetInfo{}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ var Flag FlagConfig
 type FlagConfig struct {
 	Debug     bool
 	Query     string
+	FilterTag string
 	Command   bool
 	Delimiter string
 	OneLine   bool


### PR DESCRIPTION
#168 

When I registered commands for various environments with tags, I wanted to use tags for clear filtering, so I made it possible to filter using tags.

The usage is as follows

- create snipet with tag `stg`

```
pet new -t
Command> ssh xxx@xxxx
Description> ssh to stg
Tag> stg
```

- create snipet with tag `prod`

```
pet new -t
Command> ssh xxx@xxx
Description> ssh to prod
Tag> prod
```

- exec normally

```
pet exec

  [ssh to prod]: ssh xxx@xxx #prod
> [ssh to stg]: ssh xxx@xxxx #stg
```

- exec with filter tag

```
pet exec -t stg

> [ssh to stg]: ssh xxx@xxxx #stg
  1/1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
