### PR TITLE
Fix `--quote` with spaces

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
 	"github.com/spf13/cobra"
+	"gopkg.in/alessio/shellescape.v1"
 )
 
 // execCmd represents the exec command
@@ -23,7 +24,7 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 
 	var options []string
 	if flag.Query != "" {
-		options = append(options, fmt.Sprintf("--query %s", flag.Query))
+		options = append(options, fmt.Sprintf("--query %s", shellescape.Quote(flag.Query)))
 	}
 
 	commands, err := filter(options)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -7,6 +7,7 @@ import (
 	"github.com/knqyf263/pet/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/alessio/shellescape.v1"
 )
 
 var delimiter string
@@ -24,7 +25,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 
 	var options []string
 	if flag.Query != "" {
-		options = append(options, fmt.Sprintf("--query %s", flag.Query))
+		options = append(options, fmt.Sprintf("--query %s", shellescape.Quote(flag.Query)))
 	}
 	commands, err := filter(options)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a
 	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 	google.golang.org/appengine v1.0.0 // indirect
+	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -44,3 +44,5 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 google.golang.org/appengine v1.0.0 h1:dN4LljjBKVChsv0XCSI+zbyzdqrkEwX5LQFUMRSGqOc=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 h1:8ajkpB4hXVftY5ko905id+dOnmorcS2CHNxxHLLDcFM=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61/go.mod h1:IfMagxm39Ys4ybJrDb7W3Ob8RwxftP0Yy+or/NVz1O8=


### PR DESCRIPTION
## Issue

`--query` parameter does not accept whitespaces.

```shell
$ pet search --query="a b"
unknown option: b

```

## Description of changes

Quote before passing the `--query` to fzf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
