### PR TITLE
chore(mod): update golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,6 @@ require (
 	github.com/spf13/pflag v1.0.1 // indirect
 	golang.org/x/net v0.0.0-20180530234432-1e491301e022 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c // indirect
 	google.golang.org/appengine v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a h1:1Fy38jwe/QZhQfFQBy6dMj
 golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c h1:DHcbWVXeY+0Y8HHKR+rbLwnoh2F4tNCY7rTiHJ30RmA=
+golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 google.golang.org/appengine v1.0.0 h1:dN4LljjBKVChsv0XCSI+zbyzdqrkEwX5LQFUMRSGqOc=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 h1:8ajkpB4hXVftY5ko905id+dOnmorcS2CHNxxHLLDcFM=


### PR DESCRIPTION
Address the following error.

```
   ⨯ release failed after 60.74s error=failed to build for windows_arm64: exit status 2: # golang.org/x/sys/windows
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/windows/zsyscall_windows.go:2761:38: undefined: WSAData
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/windows/zsyscall_windows.go:3001:51: undefined: Servent
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/windows/zsyscall_windows.go:3015:50: undefined: Servent
```