### PR TITLE
chore: use personal access token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,4 +28,4 @@ jobs:
           version: v1.0.0
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PET_PAT }}


### PR DESCRIPTION
GITHUB_TOKEN doesn't have the permission to update knqyf263/homebrew-pet