### PR TITLE
make command runner configurable

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -38,7 +38,7 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 	if config.Flag.Command {
 		fmt.Printf("%s: %s\n", color.YellowString("Command"), command)
 	}
-	return run(command, os.Stdin, os.Stdout)
+	return run(command, os.Stdin, os.Stdout, &config.Conf.General)
 }
 
 func init() {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -17,12 +17,15 @@ import (
 
 func editFile(command, file string) error {
 	command += " " + file
-	return run(command, os.Stdin, os.Stdout)
+	return run(command, os.Stdin, os.Stdout, nil)
 }
 
-func run(command string, r io.Reader, w io.Writer) error {
+func run(command string, r io.Reader, w io.Writer, config *config.GeneralConfig) error {
 	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
+	if config != nil && config.CommandRunner != nil {
+		line := append(*config.CommandRunner, command)
+		cmd = exec.Command(line[0], line[1:]...)
+	} else if runtime.GOOS == "windows" {
 		cmd = exec.Command("cmd", "/c", command)
 	} else {
 		cmd = exec.Command("sh", "-c", command)
@@ -77,7 +80,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 	var buf bytes.Buffer
 	selectCmd := fmt.Sprintf("%s %s",
 		config.Conf.General.SelectCmd, strings.Join(options, " "))
-	err = run(selectCmd, strings.NewReader(text), &buf)
+	err = run(selectCmd, strings.NewReader(text), &buf, nil)
 	if err != nil {
 		return nil, nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 )
@@ -15,19 +16,20 @@ var Conf Config
 
 // Config is a struct of config
 type Config struct {
-	General GeneralConfig 	`toml:"General"`
-	Gist    GistConfig		`toml:"Gist"`
-	GitLab  GitLabConfig	`toml:"GitLab"`
+	General GeneralConfig `toml:"General"`
+	Gist    GistConfig    `toml:"Gist"`
+	GitLab  GitLabConfig  `toml:"GitLab"`
 }
 
 // GeneralConfig is a struct of general config
 type GeneralConfig struct {
-	SnippetFile string `toml:"snippetfile"`
-	Editor      string `toml:"editor"`
-	Column      int    `toml:"column"`
-	SelectCmd   string `toml:"selectcmd"`
-	Backend     string `toml:"backend"`
-	SortBy      string `toml:"sortby"`
+	SnippetFile   string    `toml:"snippetfile"`
+	Editor        string    `toml:"editor"`
+	Column        int       `toml:"column"`
+	SelectCmd     string    `toml:"selectcmd"`
+	Backend       string    `toml:"backend"`
+	SortBy        string    `toml:"sortby"`
+	CommandRunner *[]string `toml:"commandrunner"`
 }
 
 // GistConfig is a struct of config for Gist
@@ -126,7 +128,7 @@ func GetDefaultConfigDir() (dir string, err error) {
 	} else {
 		dir = filepath.Join(os.Getenv("HOME"), ".config", "pet")
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("cannot create directory: %v", err)
 	}
 	return dir, nil


### PR DESCRIPTION
*Issue #, if available:* 
none, havent reported one

*Description of changes:*
Add a config option to set a custom command runner / prelude instead of the default one. I am using fish shell which isnt posix compatible, so I am more used to fish syntax. Overwriting the default runner (which is `sh`) allows me to use a custom shell

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
