### PR TITLE
feat: support multiple default values

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	views      = []string{}
-	layoutStep = 3
-	curView    = -1
-	idxView    = 0
+	views               = []string{}
+	viewsUseMultiValues = map[string]bool{}
+	layoutStep          = 3
+	curView             = -1
+	idxView             = 0
 
 	//CurrentCommand is the command before assigning to variables
 	CurrentCommand string
@@ -57,8 +58,17 @@ func evaluateParams(g *gocui.Gui, _ *gocui.View) error {
 	for _, v := range views {
 		view, _ := g.View(v)
 		res := view.Buffer()
-		res = strings.Replace(res, "\n", "", -1)
-		paramsFilled[v] = strings.TrimSpace(res)
+		if _, ok := viewsUseMultiValues[v]; !ok {
+			res = strings.Replace(res, "\n", "", -1)
+			paramsFilled[v] = strings.TrimSpace(res)
+		} else {
+			_, cy := view.Cursor()
+			l, err := view.Line(cy)
+			if err != nil {
+				return err
+			}
+			paramsFilled[v] = strings.TrimSpace(l)
+		}
 	}
 	FinalCommand = insertParams(CurrentCommand, paramsFilled)
 	return gocui.ErrQuit


### PR DESCRIPTION
This CL supports multiple default values like <proxy=cfg1|cfg2|cfg3>,
this parameter will rendered like this in `generateView`:

```
--proxy=cfg1|cfg2|cfg3-----------|
|cfg1
|cfg2
|cfg3
|---------------------------------|
```

then we can use up/down arrow to select the wanted item, after press
`enter` evaluateResult will be executed.

This CL also let the parameter view's title use larger width.

close #192
