### PR TITLE
Added environment management capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# pet : CLI Snippet Manager
+# superpet : CLI Snippet and Environment Manager
 
 [![GitHub release](https://img.shields.io/github/release/knqyf263/pet.svg)](https://github.com/knqyf263/pet/releases/latest)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/knqyf263/pet/blob/master/LICENSE)
 
 <img src="doc/logo.png" width="150">
 
-Simple command-line snippet manager, written in Go
+Simple command-line snippet and environment manager, written in Go
 
 <img src="doc/pet01.gif" width="700">
 
@@ -32,6 +32,10 @@ Even if I register an alias, I forget the name of alias (because I rarely use th
 
 So I made it possible to register snippets with description and search them easily.
 
+I also have trouble moving between environments, and I don't like .env files (maybe I want to activate an environment from elsewhere). So I added some functionality to pet (to make it superpet) that allows configuring environments as snippets. By environments I mean a list of environment variables.
+
+- `pet activate`
+
 # TOC
 
 - [Main features](#main-features)
@@ -46,8 +50,8 @@ So I made it possible to register snippets with description and search them easi
         - [fish](#fish-1)
     - [Copy snippets to clipboard](#copy-snippets-to-clipboard)
 - [Features](#features)
-    - [Edit snippets](#edit-snippets)
-    - [Sync snippets](#sync-snippets)
+    - [Edit snippets and environments](#edit-snippets)
+    - [Sync snippets and environments](#sync-snippets)
 - [Hands-on Tutorial](#hands-on-tutorial)
 - [Usage](#usage)
 - [Snippet](#snippet)
@@ -214,6 +218,15 @@ Description: Show expiration date of SSL certificate
 ------------------------------
 ```
 
+Run `pet listenv`
+
+```
+Description: Show expiration date of SSL certificate
+     Variables: [HOST, PORT, SENTRY_URL]
+     Tags: [work, backend]
+------------------------------
+```
+
 
 # Configuration
 
@@ -296,6 +309,26 @@ You can exec snipet with filtering the tag
 $ pet exec -t google
 
 [ping]: ping 8.8.8.8 #network #google
+```
+
+## Activate
+You can activate environments, which will put you in a new shell with those environment variables set.
+
+```
+$ pet activate
+```
+
+To get out of shell:
+```
+$ exit
+```
+
+```
+$ pet edit
+[[env]]
+  description = "Work backend service"
+  variables = ["HOST=http://localhost", "PORT=8000", "SENTRY_URL=https://qwehaosd.sentry.com"]
+  tag = ["work", "backend"]
 ```
 
 ## Sync

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/knqyf263/pet/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/alessio/shellescape.v1"
+)
+
+// activateCmd represents the activate command
+var activateCmd = &cobra.Command{
+	Use:   "activate",
+	Short: "Load the selected environment",
+	Long:  `Load the selected environment`,
+	RunE:  activate,
+}
+
+func activate(cmd *cobra.Command, args []string) (err error) {
+	flag := config.Flag
+
+	var options []string
+	if flag.Query != "" {
+		options = append(options, fmt.Sprintf("--query %s", shellescape.Quote(flag.Query)))
+	}
+
+	envs, err := filterEnv(options, flag.FilterTag)
+	if err != nil {
+		return err
+	}
+
+	// Create new shell and add env vars to it (overwriting old values)
+	ex := exec.Command("zsh", "-i")
+	ex.Env = os.Environ()
+	ex.Env = append(ex.Env, envs...)
+
+	// Attach stdin, stdout to new shell
+	ex.Stdin = os.Stdin
+	ex.Stdout = os.Stdout
+	ex.Stderr = os.Stderr
+	err = ex.Run() // add error checking
+
+	fmt.Println("exited superpet shell")
+
+	return err
+}
+
+func init() {
+	RootCmd.AddCommand(activateCmd)
+	activateCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
+		`Initial value for query`)
+	activateCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
+		`Filter tag`)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
+	"github.com/knqyf263/pet/envvar"
 	"github.com/knqyf263/pet/snippet"
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
@@ -21,6 +22,13 @@ var listCmd = &cobra.Command{
 	Short: "Show all snippets",
 	Long:  `Show all snippets`,
 	RunE:  list,
+}
+
+var listenvCmd = &cobra.Command{
+	Use:   "listenv",
+	Short: "Show all env vars",
+	Long:  `Show all env vars`,
+	RunE:  listenv,
 }
 
 func list(cmd *cobra.Command, args []string) error {
@@ -74,8 +82,53 @@ func list(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func listenv(cmd *cobra.Command, args []string) error {
+	var envvars envvar.EnvVar
+	if err := envvars.Load(); err != nil {
+		return err
+	}
+
+	col := config.Conf.General.Column
+	if col == 0 {
+		col = column
+	}
+
+	fmt.Println("")
+	for _, envvar := range envvars.EnvVars {
+		var variables []string
+		for _, value := range envvar.Variables {
+			values := strings.Split(value, "=")
+			variables = append(variables, values[0])
+		}
+		vars := strings.Join(variables, ", ")
+
+		if config.Flag.OneLine {
+			description := runewidth.FillRight(runewidth.Truncate(envvar.Description, col, "..."), col)
+			vars = runewidth.Truncate(vars, 100-4-col, "...")
+			// make sure multiline vars printed as oneline
+			vars = strings.Replace(vars, "\n", "\\n", -1)
+			fmt.Fprintf(color.Output, "%s : %s\n",
+				color.GreenString(description), color.YellowString(vars))
+		} else {
+			fmt.Fprintf(color.Output, "%12s %s\n",
+				color.GreenString("Description:"), envvar.Description)
+			fmt.Fprintf(color.Output, "%12s %s\n",
+				color.YellowString("    Variables:"), vars)
+
+			if envvar.Tag != nil {
+				tag := strings.Join(envvar.Tag, " ")
+				fmt.Fprintf(color.Output, "%12s %s\n",
+					color.CyanString("        Tag:"), tag)
+			}
+			fmt.Println(strings.Repeat("-", 30))
+		}
+	}
+	return nil
+}
+
 func init() {
 	RootCmd.AddCommand(listCmd)
+	RootCmd.AddCommand(listenvCmd)
 	listCmd.Flags().BoolVarP(&config.Flag.OneLine, "oneline", "", false,
 		`Display snippets in one line`)
 }

--- a/envvar/envvar.go
+++ b/envvar/envvar.go
@@ -1,0 +1,91 @@
+package envvar
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/knqyf263/pet/config"
+)
+
+type EnvVar struct {
+	EnvVars []EnvVarInfo `toml:"env"`
+}
+
+type EnvVarInfo struct {
+	Description string   `toml:"description"`
+	Variables   []string `toml:"variables"`
+	Tag         []string `toml:"tag"`
+}
+
+func (envvar *EnvVarInfo) GetVariables() []string {
+	var variables []string
+	for _, variable := range envvar.Variables {
+		variables = append(variables, strings.Split(variable, "=")[0])
+	}
+	return variables
+}
+
+// Load reads toml file.
+func (envvars *EnvVar) Load() error {
+	configFile := config.Conf.General.SnippetFile
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return nil
+	}
+	if _, err := toml.DecodeFile(configFile, envvars); err != nil {
+		return fmt.Errorf("failed to load snippet file. %v", err)
+	}
+	envvars.Order()
+	return nil
+}
+
+// Save saves the snippets to toml file.
+func (envvar *EnvVar) Save() error {
+	snippetFile := config.Conf.General.SnippetFile
+	f, err := os.Create(snippetFile)
+	if err != nil {
+		return fmt.Errorf("failed to save snippet file. err: %s", err)
+	}
+	defer f.Close()
+	return toml.NewEncoder(f).Encode(envvar)
+}
+
+// ToString returns the contents of toml file.
+func (snippets *EnvVar) ToString() (string, error) {
+	var buffer bytes.Buffer
+	err := toml.NewEncoder(&buffer).Encode(snippets)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert struct to TOML string: %v", err)
+	}
+	return buffer.String(), nil
+}
+
+// Order snippets regarding SortBy option defined in config toml
+// Prefix "-" reverses the order, default is "recency", "+<expressions>" is the same as "<expression>"
+func (envvars *EnvVar) Order() {
+	sortBy := config.Conf.General.SortBy
+	switch {
+	case sortBy == "description" || sortBy == "+description":
+		sort.Sort(ByDescription(envvars.EnvVars))
+	case sortBy == "-description":
+		sort.Sort(sort.Reverse(ByDescription(envvars.EnvVars)))
+
+	case sortBy == "-recency":
+		envvars.reverse()
+	}
+}
+
+func (envvars *EnvVar) reverse() {
+	for i, j := 0, len(envvars.EnvVars)-1; i < j; i, j = i+1, j-1 {
+		envvars.EnvVars[i], envvars.EnvVars[j] = envvars.EnvVars[j], envvars.EnvVars[i]
+	}
+}
+
+type ByDescription []EnvVarInfo
+
+func (a ByDescription) Len() int           { return len(a) }
+func (a ByDescription) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByDescription) Less(i, j int) bool { return a[i].Description > a[j].Description }


### PR DESCRIPTION
This PR adds some environment variable management capabilities to pet. Does this by saving env vars in "snippets" that have a tag of [[env]] (piggybacking on the sync), and activating environments by spawning a new shell with those env vars set up there (`activate` command).

Not sure if this is a change that is wanted in Pet, but I'll be adding this functionality to my company's pet users since its something we really want.

Still missing `add` command but will do that soon.

Just submitting this to see if anyone is interested in adding such functionality to pet.

- activate command
- listenv command
- updated toml config