### PR TITLE
fix regexp match and add test

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -29,7 +29,7 @@ func insertParams(command string, params map[string]string) string {
 
 // SearchForParams returns variables from a command
 func SearchForParams(lines []string) map[string]string {
-	re := `<([\S].+?[\S])>`
+	re := `<(\w+?(?:=.+?)?)>`
 	if len(lines) == 1 {
 		r, _ := regexp.Compile(re)
 

--- a/dialog/params_test.go
+++ b/dialog/params_test.go
@@ -1,0 +1,29 @@
+package dialog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSearchForParams(t *testing.T) {
+	type args struct {
+		lines []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{"01", args{[]string{"... <domain>"}}, map[string]string{"<domain>": ""}},
+		{"02", args{[]string{"... <domain=example.com>"}}, map[string]string{"<domain=example.com>": "example.com"}},
+		{"03", args{[]string{"... <domain=example.com> <port=443>"}}, map[string]string{"<domain=example.com>": "example.com", "<port=443>": "443"}},
+		{"04", args{[]string{"cat <<EOF > <file=path/to/file>\nEOF"}}, map[string]string{"<file=path/to/file>": "path/to/file"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SearchForParams(tt.args.lines); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchForParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`SearchForParams` function will be fine in most of case, but the following text won't work.

```bash
# command 
cat <<EOF > <file=path/to/file>
EOF
```
In general, the param name must be characters, so I replaced `\S` to `\w`, and the unit test was submitted.