### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/knqyf263/pet/config"
 	petSync "github.com/knqyf263/pet/sync"
@@ -44,7 +44,7 @@ func edit(cmd *cobra.Command, args []string) (err error) {
 }
 
 func fileContent(fname string) string {
-	data, _ := ioutil.ReadFile(fname)
+	data, _ := os.ReadFile(fname)
 	return string(data)
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -108,5 +107,5 @@ func download(content string) error {
 	}
 
 	fmt.Println("Download success")
-	return ioutil.WriteFile(snippetFile, []byte(content), os.ModePerm)
+	return os.WriteFile(snippetFile, []byte(content), os.ModePerm)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
