### PR TITLE
Enhance using same params with different default values

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -20,11 +20,35 @@ var (
 )
 
 func insertParams(command string, params map[string]string) string {
-	resultCommand := command
+	resultCommand := normalizeCommand(command)
 	for k, v := range params {
-		resultCommand = strings.Replace(resultCommand, k, v, -1)
+		resultCommand = strings.Replace(resultCommand, normalizeParam(k), v, -1)
 	}
 	return resultCommand
+}
+
+// strips param of default value
+func normalizeParam(param string) string {
+    splits := strings.SplitN(param, "=", 2)
+
+    if len(splits) == 1 {
+        return splits[0]
+    }
+
+    return splits[0] + ">"
+}
+
+// returns the command with all the params stripped of default values
+func normalizeCommand(command string) string {
+    r, _ := regexp.Compile(`<([\S].+?[\S])>`)
+
+    params := r.FindAllString(command, -1)
+
+    for _, p := range params {
+        command = strings.Replace(command, p, normalizeParam(p), -1)
+    }
+
+    return command
 }
 
 // SearchForParams returns variables from a command
@@ -40,12 +64,25 @@ func SearchForParams(lines []string) map[string]string {
 
 		extracted := map[string]string{}
 		for _, p := range params {
+            normalizedP := normalizeParam(p[0])
 			splitted := strings.Split(p[1], "=")
-			if len(splitted) == 1 {
-				extracted[p[0]] = ""
-			} else {
-				extracted[p[0]] = splitted[1]
-			}
+
+            found := false
+            for key := range extracted {
+                if normalizeParam(key) == normalizedP {
+                    found = true
+                    break
+                }
+            }
+
+            if !found {
+                if len(splitted) == 1 {
+                    extracted[p[0]] = ""
+                } else {
+                    extracted[p[0]] = splitted[1]
+                }
+            }
+
 		}
 		return extracted
 	}

--- a/dialog/params_test.go
+++ b/dialog/params_test.go
@@ -1,0 +1,25 @@
+package dialog
+
+import (
+	"testing"
+)
+
+func TestNormalizeCommand(t *testing.T) {
+	output := normalizeCommand("cmd <param=1>")
+	expected := "cmd <param>"
+	assertEquals(t, output, expected)
+
+	output = normalizeCommand("cmd <param with spaces=value with spaces>")
+	expected = "cmd <param with spaces>"
+	assertEquals(t, output, expected)
+
+	output = normalizeCommand(`echo "param1: <param1>, param1: <param1=1>, param2: <param2>, param2: <param2=2>"`)
+	expected = `echo "param1: <param1>, param1: <param1>, param2: <param2>, param2: <param2>"`
+	assertEquals(t, output, expected)
+}
+
+func assertEquals(t *testing.T, output string, expected string) {
+	if output != expected {
+		t.Fatalf("\nExpected\n%s\bto be equal to\n%s", expected, output)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
#159 
*Description of changes:*
Was facing the same annoyance as issue.

`dialog.SearchForParams` now checks if a parameter with the same name has already been added to the resulting collection before inserting. Since it keys on the parameter name and not the parameter name + default value combination, defining 2 different defaults for the same parameter name eg. echo `“<param1=Hello>, <param1=World>”` would only return 1 param of default value “Hello” (Before it would return a param1 of default value “Hello” and another param1 with default value “World”).

This of course has the effect that if a param name is repeated in the same command, you only see it once in the exec dialog.

`insertParams` now needs to replace all instances of the same param name regardless of whether it has different or no default value. To do this, I made a function to normalize the parameters with defaults in the command to just their names.

I have made the assumption that the exec form showing **\<param-name\>** in the top of each input instead of just **param-name** was deliberate. If it was not and you are ok with it just saying **param-name**, the implementation would be a bit simpler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
