### PR TITLE
Have multiple commands per snippet

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
 	"github.com/knqyf263/pet/snippet"
-	runewidth "github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 )
 
@@ -35,42 +34,47 @@ func list(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, snippet := range snippets.Snippets {
-		if config.Flag.OneLine {
-			description := runewidth.FillRight(runewidth.Truncate(snippet.Description, col, "..."), col)
-			command := runewidth.Truncate(snippet.Command, 100-4-col, "...")
-			// make sure multiline command printed as oneline
-			command = strings.Replace(command, "\n", "\\n", -1)
-			fmt.Fprintf(color.Output, "%s : %s\n",
-				color.GreenString(description), color.YellowString(command))
-		} else {
-			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.GreenString("Description:"), snippet.Description)
-			if strings.Contains(snippet.Command, "\n") {
-				lines := strings.Split(snippet.Command, "\n")
-				firstLine, restLines := lines[0], lines[1:]
-				fmt.Fprintf(color.Output, "%12s %s\n",
-					color.YellowString("    Command:"), firstLine)
-				for _, line := range restLines {
-					fmt.Fprintf(color.Output, "%12s %s\n",
-						" ", line)
-				}
-			} else {
-				fmt.Fprintf(color.Output, "%12s %s\n",
-					color.YellowString("    Command:"), snippet.Command)
-			}
-			if snippet.Tag != nil {
-				tag := strings.Join(snippet.Tag, " ")
-				fmt.Fprintf(color.Output, "%12s %s\n",
-					color.CyanString("        Tag:"), tag)
-			}
-			if snippet.Output != "" {
-				output := strings.Replace(snippet.Output, "\n", "\n             ", -1)
-				fmt.Fprintf(color.Output, "%12s %s\n",
-					color.RedString("     Output:"), output)
-			}
-			fmt.Println(strings.Repeat("-", 30))
+		// TODO - Do we need this?
+		//if config.Flag.OneLine {
+		//	description := runewidth.FillRight(runewidth.Truncate(snippet.Description, col, "..."), col)
+		//	commands := runewidth.Truncate(snippet.Commands, 100-4-col, "...")
+		//	make sure multiline command printed as oneline
+		//commands = strings.Replace(command, "\n", "\\n", -1)
+		//fmt.Fprintf(color.Output, "%s : %s\n",
+		//	color.GreenString(description), color.YellowString(command))
+		//} else {
+		fmt.Fprintf(color.Output, "%12s %s\n",
+			color.GreenString("Description:"), snippet.Description)
+		// TODO - Do we need this?
+		//if strings.Contains(snippet.Commands, "\n") {
+		//	lines := strings.Split(snippet.Commands, "\n")
+		//	firstLine, restLines := lines[0], lines[1:]
+		//	fmt.Fprintf(color.Output, "%12s %s\n",
+		//		color.YellowString("    Command:"), firstLine)
+		//	for _, line := range restLines {
+		//		fmt.Fprintf(color.Output, "%12s %s\n",
+		//			" ", line)
+		//	}
+		//} else {
+		//}
+		fmt.Fprintf(color.Output, "%12s \n", color.YellowString("    Commands:"))
+		for _, command := range snippet.Commands {
+			//fmt.Fprintf(color.Output, "%12s %s\n", color.YellowString("    Commands:"), command)
+			fmt.Println("    ", command)
 		}
+		if snippet.Tag != nil {
+			tag := strings.Join(snippet.Tag, " ")
+			fmt.Fprintf(color.Output, "%12s %s\n",
+				color.CyanString("        Tag:"), tag)
+		}
+		if snippet.Output != "" {
+			output := strings.Replace(snippet.Output, "\n", "\n             ", -1)
+			fmt.Fprintf(color.Output, "%12s %s\n",
+				color.RedString("     Output:"), output)
+		}
+		fmt.Println(strings.Repeat("-", 30))
 	}
+	//}
 	return nil
 }
 

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -90,7 +90,7 @@ type ByCommand []SnippetInfo
 
 func (a ByCommand) Len() int           { return len(a) }
 func (a ByCommand) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByCommand) Less(i, j int) bool { return a[i].Command > a[j].Command }
+func (a ByCommand) Less(i, j int) bool { return len(a[i].Commands) > len(a[j].Commands) }
 
 type ByDescription []SnippetInfo
 

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -16,7 +16,7 @@ type Snippets struct {
 
 type SnippetInfo struct {
 	Description string   `toml:"description"`
-	Command     string   `toml:"command"`
+	Commands    []string `toml:"commands"`
 	Tag         []string `toml:"tag"`
 	Output      string   `toml:"output"`
 }


### PR DESCRIPTION
**Changes**

1. Can list snippets with multiple commands. They still don't look great when listing them, but it works for now.
2. Only gives an error when the description and command exist.
3. When creating a new snippet, if one with that description exists, it will append the command to its list of commands.
4. Commands are stored in an array in the toml config file now.