### PR TITLE
CLI cleanup

### DIFF
--- a/cmd/clip.go
+++ b/cmd/clip.go
@@ -47,4 +47,6 @@ func init() {
 		`Use delim as the command delimiter character`)
 	clipCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
 		`Filter tag`)
+	clipCmd.Flags().BoolVarP(&config.Flag.Color, "color", "", false,
+		`Enable colorized output (only fzf) (not working)`)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,7 +57,7 @@ func list(cmd *cobra.Command, args []string) error {
 		//	}
 		//} else {
 		//}
-		fmt.Fprintf(color.Output, "%12s \n", color.YellowString("    Commands:"))
+		fmt.Fprintf(color.Output, "%12s \n", color.YellowString("Example Commands:"))
 		for _, command := range snippet.Commands {
 			//fmt.Fprintf(color.Output, "%12s %s\n", color.YellowString("    Commands:"), command)
 			fmt.Println("    ", command)
@@ -65,12 +65,12 @@ func list(cmd *cobra.Command, args []string) error {
 		if snippet.Tag != nil {
 			tag := strings.Join(snippet.Tag, " ")
 			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.CyanString("        Tag:"), tag)
+				color.CyanString("Tag:"), tag)
 		}
 		if snippet.Output != "" {
 			output := strings.Replace(snippet.Output, "\n", "\n             ", -1)
 			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.RedString("     Output:"), output)
+				color.RedString("Output:"), output)
 		}
 		fmt.Println(strings.Repeat("-", 30))
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -42,7 +42,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 func init() {
 	RootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().BoolVarP(&config.Flag.Color, "color", "", false,
-		`Enable colorized output (only fzf)`)
+		`Enable colorized output (only fzf) (not working)`)
 	searchCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
 		`Initial value for query`)
 	searchCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ type FlagConfig struct {
 	OneLine   bool
 	Color     bool
 	Tag       bool
+	Output    bool
 }
 
 // Load loads a config toml

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,7 @@ func (cfg *Config) Load(file string) error {
 		}
 	}
 	cfg.General.Column = 40
-	cfg.General.SelectCmd = "fzf"
+	cfg.General.SelectCmd = "fzf --reverse --ansi"
 	cfg.General.Backend = "gist"
 
 	cfg.Gist.FileName = "pet-snippet.toml"

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -16,7 +16,7 @@ type Snippets struct {
 
 type SnippetInfo struct {
 	Description string   `toml:"description"`
-	Command     string   `toml:"command"`
+	Commands    []string `toml:"commands"`
 	Tag         []string `toml:"tag"`
 	Output      string   `toml:"output"`
 }


### PR DESCRIPTION
Better interaction with `list` and `new` commands
- format list view
- prompt for and handle output when using `pet new --output`

Better clip interaction
- better formatting in the fzf view
- allow copying of sub-commands or top level snippet

note: clear out your `config.toml` file to get updated fzf config for better display