### PR TITLE
Fix execution of command with quotes on windows.

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
@@ -26,7 +27,8 @@ func run(command string, r io.Reader, w io.Writer) error {
 		line := append(config.Conf.General.Cmd, command)
 		cmd = exec.Command(line[0], line[1:]...)
 	} else if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", command)
+		cmd = exec.Command("cmd.exe")
+		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}


### PR DESCRIPTION
*Issue*
#138

*Description of changes:*

Commands with quotes can't be handled on windows using standard exec.Command() calls. Based on the go documentation https://pkg.go.dev/os/exec#Command the argument handling is converted to SysProcAttr.
