### PR TITLE
Feat: allow to set several parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Simple command-line snippet manager, written in Go
 
 <img src="doc/pet01.gif" width="700">
 
-You can use variables (`<param>` or `<param=default_value>` ) in snippets.
+You can use variables (`<param>` or `<param=default_value>` or `<param=default_value|other_default_value>`) in snippets.
+ArrowDown/ArrowUp are used to switch through all default `params`.
+Ctrl-k will clear the `param` selection.
 
 <img src="doc/pet08.gif" width="700">
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
@@ -26,9 +24,6 @@ func run(command string, r io.Reader, w io.Writer) error {
 	if len(config.Conf.General.Cmd) > 0 {
 		line := append(config.Conf.General.Cmd, command)
 		cmd = exec.Command(line[0], line[1:]...)
-	} else if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd.exe")
-		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}

--- a/cmd/util_windows.go
+++ b/cmd/util_windows.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/knqyf263/pet/config"
+)
+
+func run(command string, r io.Reader, w io.Writer) error {
+	var cmd *exec.Cmd
+	if len(config.Conf.General.Cmd) > 0 {
+		line := append(config.Conf.General.Cmd, command)
+		cmd = exec.Command(line[0], line[1:]...)
+	} else {
+		cmd = exec.Command("cmd.exe")
+		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = w
+	cmd.Stdin = r
+	return cmd.Run()
+}


### PR DESCRIPTION
Small feature to allow setting a list of default parameters separated by `|` in snippet `command` fields.

Includes also a bug fix that broke building on non windows systems. 
`syscall.SysProcAttr` on non windows systems doesn't contain the field `CmdLine`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
