### PR TITLE
Fix execution of command with quotes on windows.

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,12 +3,8 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
@@ -19,23 +15,6 @@ import (
 func editFile(command, file string) error {
 	command += " " + file
 	return run(command, os.Stdin, os.Stdout)
-}
-
-func run(command string, r io.Reader, w io.Writer) error {
-	var cmd *exec.Cmd
-	if len(config.Conf.General.Cmd) > 0 {
-		line := append(config.Conf.General.Cmd, command)
-		cmd = exec.Command(line[0], line[1:]...)
-	} else if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd.exe")
-		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
-	} else {
-		cmd = exec.Command("sh", "-c", command)
-	}
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = w
-	cmd.Stdin = r
-	return cmd.Run()
 }
 
 func filter(options []string, tag string) (commands []string, err error) {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/knqyf263/pet/config"
@@ -26,7 +27,8 @@ func run(command string, r io.Reader, w io.Writer) error {
 		line := append(config.Conf.General.Cmd, command)
 		cmd = exec.Command(line[0], line[1:]...)
 	} else if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", command)
+		cmd = exec.Command("cmd.exe")
+		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}

--- a/cmd/util_unix.go
+++ b/cmd/util_unix.go
@@ -1,0 +1,25 @@
+//go:build (darwin && cgo) || linux
+
+package cmd
+
+import (
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/knqyf263/pet/config"
+)
+
+func run(command string, r io.Reader, w io.Writer) error {
+	var cmd *exec.Cmd
+	if len(config.Conf.General.Cmd) > 0 {
+		line := append(config.Conf.General.Cmd, command)
+		cmd = exec.Command(line[0], line[1:]...)
+	} else {
+		cmd = exec.Command("sh", "-c", command)
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = w
+	cmd.Stdin = r
+	return cmd.Run()
+}

--- a/cmd/util_windows.go
+++ b/cmd/util_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/knqyf263/pet/config"
+)
+
+func run(command string, r io.Reader, w io.Writer) error {
+	var cmd *exec.Cmd
+	if len(config.Conf.General.Cmd) > 0 {
+		line := append(config.Conf.General.Cmd, command)
+		cmd = exec.Command(line[0], line[1:]...)
+	} else {
+		cmd = exec.Command("cmd.exe")
+		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf("/c \"%s\"", command)}
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = w
+	cmd.Stdin = r
+	return cmd.Run()
+}


### PR DESCRIPTION
Issue
#138 #238

Description of changes:

Commands with quotes can't be handled on windows using standard exec.Command() calls. Based on the go documentation https://pkg.go.dev/os/exec#Command the argument handling is converted to SysProcAttr.

Split run function into OS dependent source files.