### PR TITLE
fix: :bug: Fixed parsing of parameters, added tests

### DIFF
--- a/dialog/params.go
+++ b/dialog/params.go
@@ -29,7 +29,7 @@ func insertParams(command string, params map[string]string) string {
 
 // SearchForParams returns variables from a command
 func SearchForParams(lines []string) map[string]string {
-	re := `<([\S].+?[\S])>`
+	re := `<([\S]+?)>`
 	if len(lines) == 1 {
 		r, _ := regexp.Compile(re)
 
@@ -41,10 +41,14 @@ func SearchForParams(lines []string) map[string]string {
 		extracted := map[string]string{}
 		for _, p := range params {
 			splitted := strings.Split(p[1], "=")
-			if len(splitted) == 1 {
-				extracted[p[0]] = ""
-			} else {
-				extracted[p[0]] = splitted[1]
+			key := splitted[0]
+			_, param_exists := extracted[key]
+
+			// Set to empty if no value is provided and param is not already set
+			if len(splitted) == 1 && !param_exists {
+				extracted[key] = ""
+			} else if len(splitted) > 1 {
+				extracted[key] = splitted[1]
 			}
 		}
 		return extracted

--- a/dialog/params_test.go
+++ b/dialog/params_test.go
@@ -1,0 +1,186 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestSearchForParams(t *testing.T) {
+	command := "<a=1> <b> hello"
+
+	params := map[string]string{
+		"a": "1",
+		"b": "",
+	}
+
+	got := SearchForParams([]string{command})
+
+	for key, value := range params {
+		if got[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+
+	for key, value := range got {
+		if params[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+}
+
+func TestSearchForParams_WithNoParams(t *testing.T) {
+	command := "no params"
+
+	got := SearchForParams([]string{command})
+
+	if got != nil {
+		t.Fatalf("wanted nil, got '%v'", got)
+	}
+}
+
+func TestSearchForParams_WithMultipleParams(t *testing.T) {
+	command := "<a=1> <b> <c=3>"
+
+	params := map[string]string{
+		"a": "1",
+		"b": "",
+		"c": "3",
+	}
+
+	got := SearchForParams([]string{command})
+
+	for key, value := range params {
+		if got[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+
+	for key, value := range got {
+		if params[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+}
+
+func TestSearchForParams_WithEmptyCommand(t *testing.T) {
+	command := ""
+
+	got := SearchForParams([]string{command})
+
+	if got != nil {
+		t.Fatalf("wanted nil, got '%v'", got)
+	}
+}
+
+func TestSearchForParams_WithNewline(t *testing.T) {
+	command := "<a=1> <b> hello\n<c=3>"
+
+	params := map[string]string{
+		"a": "1",
+		"b": "",
+		"c": "3",
+	}
+
+	got := SearchForParams([]string{command})
+
+	for key, value := range params {
+		if got[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+
+	for key, value := range got {
+		if params[key] != value {
+			t.Fatalf("wanted param '%s' to equal '%s', got '%s'", key, value, got[key])
+		}
+	}
+}
+
+func TestSearchForParams_InvalidParamFormat(t *testing.T) {
+	command := "<a=1 <b> hello"
+	want := map[string]string{
+		"b": "",
+	}
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKey(t *testing.T) {
+	command := "<a=1> <a=2> <a=3>"
+	want := map[string]string{
+		"a": "3",
+	}
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKeyDifferentValues(t *testing.T) {
+	command := "<a=1> <a=2> <a=3>"
+	want := map[string]string{
+		"a": "3",
+	}
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKeyDifferentValues_MultipleLines(t *testing.T) {
+	command := "<a=1> <a=2> <a=3>\n<b=4>"
+	want := map[string]string{
+		"a": "3",
+		"b": "4",
+	}
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKeyDifferentValues_InvalidFormat(t *testing.T) {
+	command := "<a=1> <a=2 <a=3>"
+	want := map[string]string{
+		"a": "3",
+	}
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKeyDifferentValues_InvalidFormat_MultipleLines(t *testing.T) {
+	command := "<a=1> <a=2> <a=3 \n<b=4>"
+	want := map[string]string{
+		"a": "2",
+		"b": "4",
+	}
+
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestSearchForParams_MultipleParamsSameKeyDifferentValues_InvalidFormat_MultipleLines2(t *testing.T) {
+	command := "<a=1> <a=2> <a=3>\n<b=4"
+	want := map[string]string{
+		"a": "3",
+	}
+
+	got := SearchForParams([]string{command})
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 
 require (
 	github.com/alessio/shellescape v1.4.1 // indirect
+	github.com/go-test/deep v1.1.0 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github v15.0.0+incompatible h1:jlPg2Cpsxb/FyEV/MFiIE9tW/2RAevQNZDPeHbf5a94=


### PR DESCRIPTION
Closes #159, #206.

*Description of changes:*
- Fixed regex string for extracting parameters (`<([\S].+?[\S])>` did not work for single character variables, changed to `<([\S]+?)>`)
- Improved extraction logic by taking key without <>
- Added tests for parameter parsing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
