### PR TITLE
new: tempfile-handling

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -26,7 +26,9 @@ var newCmd = &cobra.Command{
 }
 
 func scan(message string) (string, error) {
-	tempFile := "/tmp/pet.tmp"
+	f, err := os.CreateTemp("", "pet-")
+	tempFile := f.Name()
+	defer os.Remove(f.Name()) // clean up
 	if runtime.GOOS == "windows" {
 		tempDir := os.Getenv("TEMP")
 		tempFile = filepath.Join(tempDir, "pet.tmp")


### PR DESCRIPTION
replace `/tmp/pet.tmp` with a file created by `os.CreateTmp` which is no more world readable and will also be removed on exit.

https://pkg.go.dev/os#CreateTemp
https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/os/tempfile.go


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
