### PR TITLE
Added multiple parameter support via two character separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,26 @@ So I made it possible to register snippets with description and search them easi
 `pet` has the following features.
 
 - Register your command snippets easily.
-- Use variables in snippets.
+- Use variables (with one or several default values) in snippets.
 - Search snippets interactively.
 - Run snippets directly.
 - Edit snippets easily (config is just a TOML file).
 - Sync snippets via Gist or GitLab Snippets automatically.
+
+# Parameters
+There are `<n_ways>` ways of entering parameters.
+
+They can contain default values: Hello `<subject=world>`
+defined by the equal sign. 
+
+They can even contain `<content=spaces & = signs>` where the default value would be \<content=<mark>spaces & = signs</mark>\>.
+
+Default values just can't \<end with spaces \>.
+
+They can also contain multiple default values:
+Hello `<subject=|_John_||_Sam_||_Jane Doe = special #chars_|>`
+
+The values in this case would be :Hello \<subject=\|\_<mark>John</mark>\_\|\|\_<mark>Sam</mark>\_\|\|\_<mark>Jane Doe = special #chars</mark>\_\|\>
 
 # Examples
 Some examples are shown below.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ So I made it possible to register snippets with description and search them easi
 # TOC
 
 - [Main features](#main-features)
+- [Parameters] (#parameters)
 - [Examples](#examples)
   - [Register the previous command easily](#register-the-previous-command-easily)
     - [bash](#bash-prev-function)

--- a/dialog/params.go
+++ b/dialog/params.go
@@ -18,11 +18,11 @@ var (
 	// This matches most encountered patterns
 	// Skips match if there is a whitespace at the end ex. <param='my >
 	// Ignores <, > characters since they're used to match the pattern
-	patternRegex = `<([^<>]*[^\s])>`
+	parameterStringRegex = `<([^<>]*[^\s])>`
 )
 
 func insertParams(command string, filledInParams map[string]string) string {
-	r := regexp.MustCompile(patternRegex)
+	r := regexp.MustCompile(parameterStringRegex)
 
 	matches := r.FindAllStringSubmatch(command, -1)
 	if len(matches) == 0 {
@@ -48,7 +48,7 @@ func insertParams(command string, filledInParams map[string]string) string {
 
 // SearchForParams returns variables from a command
 func SearchForParams(command string) [][2]string {
-	r := regexp.MustCompile(patternRegex)
+	r := regexp.MustCompile(parameterStringRegex)
 
 	params := r.FindAllStringSubmatch(command, -1)
 	if len(params) == 0 {

--- a/dialog/params_test.go
+++ b/dialog/params_test.go
@@ -211,6 +211,21 @@ func TestSearchForParams_EqualsInDefaultValueIgnored(t *testing.T) {
 	}
 }
 
+func TestSearchForParams_MultipleDefaultValuesDoNotBreakFunction(t *testing.T) {
+	command := "echo \"<param=|_Hello_||_Hello world_||_How are you?_|> <second=Hello>, <third>\""
+	want := [][2]string{
+		{"param", "|_Hello_||_Hello world_||_How are you?_|"},
+		{"second", "Hello"},
+		{"third", ""},
+	}
+
+	got := SearchForParams(command)
+
+	if diff := deep.Equal(want, got); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
 func TestInsertParams(t *testing.T) {
 	command := "<a=1> <a> <b> hello"
 

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/awesome-gocui/gocui"
 )
@@ -10,9 +11,12 @@ import (
 var (
 	layoutStep = 3
 	curView    = -1
+
+	// This is for matching multiple default values in parameters
+	parameterMultipleValueRegex = `(\|_.*?_\|)`
 )
 
-func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable bool) error {
+func generateSingleParameterView(g *gocui.Gui, desc string, defaultParam string, coords []int, editable bool) error {
 	if StringInSlice(desc, views) {
 		return nil
 	}
@@ -20,7 +24,7 @@ func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable
 		if err != gocui.ErrUnknownView {
 			return err
 		}
-		fmt.Fprint(v, fill)
+		fmt.Fprint(v, defaultParam)
 	}
 	view, _ := g.View(desc)
 	view.Title = desc
@@ -30,6 +34,61 @@ func generateView(g *gocui.Gui, desc string, fill string, coords []int, editable
 
 	views = append(views, desc)
 
+	return nil
+}
+
+func generateMultipleParameterView(g *gocui.Gui, desc string, defaultParams []string, coords []int, editable bool) error {
+	if StringInSlice(desc, views) {
+		return nil
+	}
+
+	currentOpt := 0
+	maxOpt := len(defaultParams)
+
+	if v, err := g.SetView(desc, coords[0], coords[1], coords[2], coords[3], 0); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		g.SetKeybinding(v.Name(), gocui.KeyArrowDown, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+			if maxOpt == 0 {
+				return nil
+			}
+			next := currentOpt + 1
+			if next >= maxOpt {
+				next = currentOpt
+			}
+			v.Clear()
+			fmt.Fprint(v, defaultParams[next])
+			currentOpt = next
+			return nil
+		})
+		g.SetKeybinding(v.Name(), gocui.KeyArrowUp, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+			if maxOpt == 0 {
+				return nil
+			}
+			prev := currentOpt - 1
+			if prev < 0 {
+				prev = currentOpt
+			}
+			v.Clear()
+			fmt.Fprint(v, defaultParams[prev])
+			currentOpt = prev
+			return nil
+		})
+		g.SetKeybinding(v.Name(), gocui.KeyCtrlK, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+			v.Clear()
+			return nil
+		})
+
+		fmt.Fprint(v, defaultParams[currentOpt])
+	}
+
+	view, _ := g.View(desc)
+	view.Title = desc
+	view.Wrap = false
+	view.Autoscroll = true
+	view.Editable = editable
+	views = append(views, desc)
 	return nil
 }
 
@@ -51,7 +110,7 @@ func GenerateParamsLayout(params [][2]string, command string) {
 	leftX := (maxX / 2) - (maxX / 3)
 	rightX := (maxX / 2) + (maxX / 3)
 
-	generateView(g, "Command(TAB => Select next, ENTER => Execute command):",
+	generateSingleParameterView(g, "Command(TAB => Select next, ENTER => Execute command):",
 		command, []int{leftX, maxY / 10, rightX, maxY/10 + 5}, false)
 	idx := 0
 
@@ -59,12 +118,32 @@ func GenerateParamsLayout(params [][2]string, command string) {
 	for _, pair := range params {
 		// Unpack parameter key and value
 		k, v := pair[0], pair[1]
-		generateView(g, k, v,
-			[]int{leftX,
-				(maxY / 4) + (idx+1)*layoutStep,
-				rightX,
-				(maxY / 4) + 2 + (idx+1)*layoutStep},
-			true)
+
+		// Handle multiple default values
+		r := regexp.MustCompile(parameterMultipleValueRegex)
+		matches := r.FindAllStringSubmatch(command, -1)
+		if len(matches) > 0 {
+			parameters := []string{}
+			for _, p := range matches {
+				_, matchedGroup := p[0], p[1]
+				// Remove the separators
+				matchedGroup = matchedGroup[2 : len(matchedGroup)-2]
+				parameters = append(parameters, matchedGroup)
+			}
+			generateMultipleParameterView(
+				g, k, parameters, []int{leftX,
+					(maxY / 4) + (idx+1)*layoutStep,
+					rightX,
+					(maxY / 4) + 2 + (idx+1)*layoutStep},
+				true)
+		} else {
+			generateSingleParameterView(g, k, v,
+				[]int{leftX,
+					(maxY / 4) + (idx+1)*layoutStep,
+					rightX,
+					(maxY / 4) + 2 + (idx+1)*layoutStep},
+				true)
+		}
 		idx++
 	}
 

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -82,9 +82,16 @@ func generateMultipleParameterView(g *gocui.Gui, desc string, defaultParams []st
 
 		fmt.Fprint(v, defaultParams[currentOpt])
 	}
-
+	
 	view, _ := g.View(desc)
-	view.Title = desc
+	viewTitle := desc
+	// Adjust view title to hint the user about the available 
+	// options if there are more than one
+	if maxOpt > 1 {
+		viewTitle = desc + " (UP/DOWN => Select default value)"
+	}
+	
+	view.Title = viewTitle
 	view.Wrap = false
 	view.Autoscroll = true
 	view.Editable = editable
@@ -117,12 +124,14 @@ func GenerateParamsLayout(params [][2]string, command string) {
 	// Create a view for each param
 	for _, pair := range params {
 		// Unpack parameter key and value
-		k, v := pair[0], pair[1]
+		parameterKey, parameterValue := pair[0], pair[1]
 
-		// Handle multiple default values
+		// Check value for multiple defaults
 		r := regexp.MustCompile(parameterMultipleValueRegex)
-		matches := r.FindAllStringSubmatch(command, -1)
+		matches := r.FindAllStringSubmatch(parameterValue, -1)
+
 		if len(matches) > 0 {
+			// Extract the default values and generate multiple params view
 			parameters := []string{}
 			for _, p := range matches {
 				_, matchedGroup := p[0], p[1]
@@ -131,14 +140,17 @@ func GenerateParamsLayout(params [][2]string, command string) {
 				parameters = append(parameters, matchedGroup)
 			}
 			generateMultipleParameterView(
-				g, k, parameters, []int{leftX,
+				g, parameterKey, parameters, []int{
+					leftX,
 					(maxY / 4) + (idx+1)*layoutStep,
 					rightX,
 					(maxY / 4) + 2 + (idx+1)*layoutStep},
 				true)
 		} else {
-			generateSingleParameterView(g, k, v,
-				[]int{leftX,
+			// Generate single param view using the single value
+			generateSingleParameterView(g, parameterKey, parameterValue,
+				[]int{
+					leftX,
 					(maxY / 4) + (idx+1)*layoutStep,
 					rightX,
 					(maxY / 4) + 2 + (idx+1)*layoutStep},


### PR DESCRIPTION
*Issue #, if available:* #192, #203, #239, #250, #247

## *Description of changes:*

✨ This introduces support for multiple default values in parameters ✨  

Based this off @hitzhangjie's and @morriswinkler 's PRs! Thanks for laying all of the groundwork 😄

The proposed solution would work as follows:
<param=`|_first value_||_second value here_||_third value can be = anything too _|`>

The characters were chosen to minimize conflicts with shell languages, and mirroring was used to reduce that chance even further.

On a technical level, we still match the general parameters in the same way. But before creating the parameter layout for filling the parameter values, we split the value into several values if multiple are present. If not, we keep the same logic as before. This ensures backwards compatibility.

![multiple-default-values](https://github.com/knqyf263/pet/assets/8523191/4e812186-04c2-46db-805f-30145a032a55)