### PR TITLE
Make it work on Windows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func (cfg *Config) Load(file string) error {
 		}
 	}
 	cfg.General.Column = 40
-	cfg.General.SelectCmd = "fzf --ansi --layout=reverse --border --height=90% --pointer='*' --cycle --prompt='Snippets: '"
+	cfg.General.SelectCmd = "fzf --ansi --layout=reverse --border --height=90% --pointer=* --cycle --prompt=Snippets:"
 	cfg.General.Backend = "gist"
 
 	cfg.Gist.FileName = "pet-snippet.toml"


### PR DESCRIPTION
Hi there 👋

I decided to try out pet today on my Windows PC, and was surprised to find that it did not work. I did a little bit of digging, and realized the problem was with the command that pet is sending to `fzf` Fuzzy Finder. I tinkered with it until I got it working. I'm now making this PR to share my fix.

*Description of changes:*
I needed to change this line from:
https://github.com/knqyf263/pet/blob/19dc6b229e53b2dc6a79127b9bd50b03cd787aef/config/config.go#L109

to this in order to make pet work on Windows with fzf:

```go
        cfg.General.SelectCmd = "fzf --ansi --layout=reverse --border --height=90% --pointer=* --cycle --prompt=Snippets:"
```

Only after making these changes did it work on Windows.

Now I don't actually expect you to change the source code to this because I don't know how this code affects Linux machines (and I'm not testing it rn), but perhaps you can test it. If it works, great! If it doesn't, add some sort of case checker to see if the Windows zip file is being built, and use this line in config.go instead.

Hope this helps, pet is a lovely utility ❤️ 

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._