### PR TITLE
Fixed markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ So I made it possible to register snippets with description and search them easi
 # TOC
 
 - [Main features](#main-features)
-- [Parameters] (#parameters)
+- [Parameters](#parameters)
 - [Examples](#examples)
   - [Register the previous command easily](#register-the-previous-command-easily)
     - [bash](#bash-prev-function)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixed a markdown link that contained unnecessary space between the brackets and the parentheses.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
