### PR TITLE
removed hands on tutorial from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,6 @@ You can share snippets via Gist.
 
 <img src="doc/pet05.gif" width="700">
 
-# Hands-on Tutorial
-
-To experience `pet` in action, try it out in this free O'Reilly Katacoda scenario, [Pet, a CLI Snippet Manager](https://katacoda.com/javajon/courses/kubernetes-tools/snippets-pet). As an example, you'll see how `pet` may enhance your productivity with the Kubernetes `kubectl` tool. Explore how you can use `pet` to curated a library of helpful snippets from the 800+ command variations with `kubectl`.
-
 # Usage
 
 ```


### PR DESCRIPTION
Per their website:
> Thank you to the Katacoda community for your years of support. Katacoda.com is now closed. Learn more about this decision and access interactive learning on O’Reilly [here](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html).

*Issue #, if available:*

*Description of changes:* Removed the link to a now unavailable tutorial.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
