### PR TITLE
Multiline snippet rebased

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -15,7 +15,7 @@ var configureCmd = &cobra.Command{
 
 func configure(cmd *cobra.Command, args []string) (err error) {
 	editor := config.Conf.General.Editor
-	return editFile(editor, configFile)
+	return editFile(editor, configFile, 0)
 }
 
 func init() {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -23,7 +23,7 @@ func edit(cmd *cobra.Command, args []string) (err error) {
 	// file content before editing
 	before := fileContent(snippetFile)
 
-	err = editFile(editor, snippetFile)
+	err = editFile(editor, snippetFile, 0)
 	if err != nil {
 		return
 	}

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -47,9 +47,9 @@ func TestScan(t *testing.T) {
 func TestScan_EmptyStringWithAllowEmpty(t *testing.T) {
 	message := "Enter something: "
 
-	input := "\n" // Simulated user input
-	want := ""    // Expected output
-	expectedError := error(nil)
+	input := "\n"               // Simulated user input
+	want := ""                  // Expected output
+	expectedError := error(nil) // Should not error
 
 	// Create a buffer for output
 	var outputBuffer bytes.Buffer
@@ -61,7 +61,7 @@ func TestScan_EmptyStringWithAllowEmpty(t *testing.T) {
 	// Check if the input was printed
 	got := result
 
-	// Check if the result matches the expected result
+	// Check if the result is empty
 	if want != got {
 		t.Errorf("Expected result %q, but got %q", want, got)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -57,14 +57,16 @@ var Flag FlagConfig
 
 // FlagConfig is a struct of flag
 type FlagConfig struct {
-	Debug     bool
-	Query     string
-	FilterTag string
-	Command   bool
-	Delimiter string
-	OneLine   bool
-	Color     bool
-	Tag       bool
+	Debug        bool
+	Query        string
+	FilterTag    string
+	Command      bool
+	Delimiter    string
+	OneLine      bool
+	Color        bool
+	Tag          bool
+	UseMultiLine bool
+	UseEditor    bool
 }
 
 // Load loads a config toml

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
 
@@ -73,7 +73,8 @@ type FlagConfig struct {
 func (cfg *Config) Load(file string) error {
 	_, err := os.Stat(file)
 	if err == nil {
-		_, err := toml.DecodeFile(file, cfg)
+		f, err := os.ReadFile(file)
+		err = toml.Unmarshal(f, cfg)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,11 @@ require (
 	github.com/google/go-github v15.0.0+incompatible
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-runewidth v0.0.10
+	github.com/jroimartin/gocui v0.4.0
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 // indirect
+	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/knqyf263/pet
 go 1.20
 
 require (
-	github.com/BurntSushi/toml v0.3.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
 	github.com/chzyer/logex v1.1.10 // indirect
@@ -12,12 +11,10 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/google/go-github v15.0.0+incompatible
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mattn/go-runewidth v0.0.10
-	github.com/jroimartin/gocui v0.4.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
-	github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 // indirect
-	github.com/pelletier/go-toml v1.8.1 // indirect
+	github.com/mattn/go-runewidth v0.0.10
+	github.com/pelletier/go-toml v1.8.1
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1 // indirect
@@ -43,8 +40,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,10 @@ github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 h1:LspjgiiJb/DZ7UVtzoAdjGX29eb6VQwFWGgdC6fguB4=
+github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/BurntSushi/toml v0.3.0 h1:e1/Ivsx3Z0FVTV0NSOv/aVgbUWyQuzj7DDnFblkRvsY=
-github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -47,8 +45,6 @@ github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862 h1:LspjgiiJb/DZ7UVtzoAdjGX29eb6VQwFWGgdC6fguB4=
-github.com/nsf/termbox-go v0.0.0-20180509163535-21a4d435a862/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/knqyf263/pet/config"
 )
 
@@ -27,9 +27,11 @@ func (snippets *Snippets) Load() error {
 	if _, err := os.Stat(snippetFile); os.IsNotExist(err) {
 		return nil
 	}
-	if _, err := toml.DecodeFile(snippetFile, snippets); err != nil {
+	f, err := os.ReadFile(snippetFile)
+	if err != nil {
 		return fmt.Errorf("Failed to load snippet file. %v", err)
 	}
+	toml.Unmarshal(f, snippets)
 	snippets.Order()
 	return nil
 }

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -16,7 +16,7 @@ type Snippets struct {
 
 type SnippetInfo struct {
 	Description string   `toml:"description"`
-	Command     string   `toml:"command"`
+	Command     string   `toml:"command" multiline:"true"`
 	Tag         []string `toml:"tag"`
 	Output      string   `toml:"output"`
 }


### PR DESCRIPTION
*Description of changes:*
- Adds support for creating a multi-line snippet using `pet new -m` or `pet new --multiline`
- Adds support for creating a new snippet using the defined text editor with `pet new -e` or `pet new --editor`

