### PR TITLE
Add autosync before edit for new and edit commands

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -20,6 +20,13 @@ func edit(cmd *cobra.Command, args []string) (err error) {
 	editor := config.Conf.General.Editor
 	snippetFile := config.Conf.General.SnippetFile
 
+	// Sync snippets beforehand to get the latest version if the remote is newer
+	if config.Conf.Gist.AutoSync {
+		if err := petSync.AutoSync(snippetFile); err != nil {
+			return err
+		}
+	}
+
 	// file content before editing
 	before := fileContent(snippetFile)
 


### PR DESCRIPTION
*Issue #, if available:*
#57 

*Description of changes:*
Currently, snippets are lost when autosync is enabled and snippets are added from different machines. 
Now, auto sync is called both before and after a new snippet is added to the local file. This means remote changes will not be overwritten. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
