### PR TITLE
Add color flag in config

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -55,7 +55,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 		t += tags
 
 		snippetTexts[t] = s
-		if config.Flag.Color {
+		if config.Flag.Color || config.Conf.General.Color {
 			t = fmt.Sprintf("[%s]: %s%s",
 				color.HiRedString(s.Description), command, color.HiCyanString(tags))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type GeneralConfig struct {
 	SelectCmd   string
 	Backend     string
 	SortBy      string
+	Color       bool
 	Cmd         []string
 }
 
@@ -123,6 +124,7 @@ func (cfg *Config) Load(file string) error {
 	cfg.General.Column = 40
 	cfg.General.SelectCmd = "fzf --ansi --layout=reverse --border --height=90% --pointer=* --cycle --prompt=Snippets:"
 	cfg.General.Backend = "gist"
+	cfg.General.Color = false
 
 	cfg.Gist.FileName = "pet-snippet.toml"
 


### PR DESCRIPTION
*Issue #, if available:*
#134 

*Description of changes:*
- Filter (search, exec, clip) uses color if either the config flag or the command flag are set 
- Make the flag false by default if no config exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
