### PR TITLE
Add an option to format the output line as a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ pkg
 vendor/
 pet
 dist/
+
+# Tools and nix
+flake.nix
+flake.lock
+.direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Run `pet configure`
   backend = "gist"                # specify backend service to sync snippets (gist, ghe or gitlab, default: gist)
   sortby  = "description"         # specify how snippets get sorted (recency (default), -recency, description, -description, command, -command, output, -output)
   cmd = ["sh", "-c"]              # specify the command to execute the snippet with
+  color = false                   # enables output coloring with fzf, same as '--color' flag
+  format = "[$descripion]: $command $tags" controls the format of the output when searching
 
 [Gist]
   file_name = "pet-snippet.toml"  # specify gist file name

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,18 +46,27 @@ func filter(options []string, tag string) (commands []string, err error) {
 		if strings.ContainsAny(command, "\n") {
 			command = strings.Replace(command, "\n", "\\n", -1)
 		}
-		t := fmt.Sprintf("[%s]: %s", s.Description, command)
 
 		tags := ""
 		for _, tag := range s.Tag {
-			tags += fmt.Sprintf(" #%s", tag)
+			tags += fmt.Sprintf("#%s ", tag)
 		}
-		t += tags
+
+		format := "[$description]: $command $tags"
+		if config.Conf.General.Format != "" {
+			format = config.Conf.General.Format
+		}
+
+		t := strings.Replace(format, "$command", command, 1)
+		t = strings.Replace(t, "$description", s.Description, 1)
+		t = strings.Replace(t, "$tags", tags, 1)
 
 		snippetTexts[t] = s
 		if config.Flag.Color || config.Conf.General.Color {
-			t = fmt.Sprintf("[%s]: %s%s",
-				color.HiRedString(s.Description), command, color.HiCyanString(tags))
+			t = config.Conf.General.Format
+			t = strings.Replace(format, "$command", command, 1)
+			t = strings.Replace(t, "$description", color.HiRedString(s.Description), 1)
+			t = strings.Replace(t, "$tags", color.HiCyanString(tags), 1)
 		}
 		text += t + "\n"
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type GeneralConfig struct {
 	Backend     string
 	SortBy      string
 	Color       bool
+	Format      string
 	Cmd         []string
 }
 
@@ -125,6 +126,7 @@ func (cfg *Config) Load(file string) error {
 	cfg.General.SelectCmd = "fzf --ansi --layout=reverse --border --height=90% --pointer=* --cycle --prompt=Snippets:"
 	cfg.General.Backend = "gist"
 	cfg.General.Color = false
+	cfg.General.Format = "[$description]: $command $tags"
 
 	cfg.Gist.FileName = "pet-snippet.toml"
 

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -18,58 +18,58 @@ var (
 
 // createView sets up a new view with the given parameters.
 func createView(g *gocui.Gui, name string, coords []int, editable bool) (*gocui.View, error) {
-    if StringInSlice(name, views) {
-        return nil, nil
-    }
+	if StringInSlice(name, views) {
+		return nil, nil
+	}
 
-    v, err := g.SetView(name, coords[0], coords[1], coords[2], coords[3], 0)
-    if err != nil && err != gocui.ErrUnknownView {
-        return nil, err
-    }
+	v, err := g.SetView(name, coords[0], coords[1], coords[2], coords[3], 0)
+	if err != nil && err != gocui.ErrUnknownView {
+		return nil, err
+	}
 
-    v.Title = name
-    v.Wrap = true
-    v.Autoscroll = true
-    v.Editable = editable
+	v.Title = name
+	v.Wrap = true
+	v.Autoscroll = true
+	v.Editable = editable
 
-    views = append(views, name)
+	views = append(views, name)
 
-    return v, nil
+	return v, nil
 }
 
 func generateSingleParameterView(g *gocui.Gui, name string, defaultParam string, coords []int, editable bool) error {
 	view, err := createView(g, name, coords, editable)
-    if err != nil {
-        return err
-    }
+	if err != nil {
+		return err
+	}
 
 	g.SetKeybinding(view.Name(), gocui.KeyCtrlK, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		v.Clear()
 		return nil
 	})
 
-    fmt.Fprint(view, defaultParam)
+	fmt.Fprint(view, defaultParam)
 	return nil
 }
 
 func generateMultipleParameterView(g *gocui.Gui, name string, defaultParams []string, coords []int, editable bool) error {
 	view, err := createView(g, name, coords, editable)
-    if err != nil {
-        return err
-    }
+	if err != nil {
+		return err
+	}
 
 	currentOpt := 0
 	maxOpt := len(defaultParams)
 
 	fmt.Fprint(view, defaultParams[currentOpt])
-	
+
 	viewTitle := name
-	// Adjust view title to hint the user about the available 
+	// Adjust view title to hint the user about the available
 	// options if there are more than one
 	if maxOpt > 1 {
 		viewTitle = name + " (UP/DOWN => Select default value)"
 	}
-	
+
 	view.Title = viewTitle
 
 	g.SetKeybinding(view.Name(), gocui.KeyArrowDown, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding an option to format the search sting differently that is output to the command line. I feel that this customization would be helpful for some (like me) who would want the order different.

This allows for any string for example:
- "[$description]: $command $tags" -- original and default
- "$command | $description | $tags" -- reordered and different decorators
- "$command | $description" -- no tags displayed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
