### PR TITLE
Feature/early eval for parameterized options

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/knqyf263/pet/cmd/runner"
 	"github.com/knqyf263/pet/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/alessio/shellescape.v1"
@@ -35,7 +36,7 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 	// Show final command before executing it
 	fmt.Printf("> %s\n", command)
 
-	return run(command, os.Stdin, os.Stdout)
+	return runner.Run(command, os.Stdin, os.Stdout)
 }
 
 func init() {

--- a/cmd/runner/util_unix.go
+++ b/cmd/runner/util_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package cmd
+package runner
 
 import (
 	"io"
@@ -10,7 +10,7 @@ import (
 	"github.com/knqyf263/pet/config"
 )
 
-func run(command string, r io.Reader, w io.Writer) error {
+func Run(command string, r io.Reader, w io.Writer) error {
 	var cmd *exec.Cmd
 	if len(config.Conf.General.Cmd) > 0 {
 		line := append(config.Conf.General.Cmd, command)

--- a/cmd/runner/util_windows.go
+++ b/cmd/runner/util_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package cmd
+package runner
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ import (
 	"github.com/knqyf263/pet/config"
 )
 
-func run(command string, r io.Reader, w io.Writer) error {
+func Run(command string, r io.Reader, w io.Writer) error {
 	var cmd *exec.Cmd
 	if len(config.Conf.General.Cmd) > 0 {
 		line := append(config.Conf.General.Cmd, command)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/knqyf263/pet/cmd/runner"
 	"github.com/knqyf263/pet/config"
 	"github.com/knqyf263/pet/dialog"
 	"github.com/knqyf263/pet/snippet"
@@ -18,7 +19,7 @@ func editFile(command, file string, startingLine int) error {
 	// Note that this works for most unix editors (nano, vi, vim, etc)
 	// TODO: Remove for other kinds of editors - this is only for UX
 	command += " +" + strconv.Itoa(startingLine) + " " + file
-	return run(command, os.Stdin, os.Stdout)
+	return runner.Run(command, os.Stdin, os.Stdout)
 }
 
 func filter(options []string, tag string) (commands []string, err error) {
@@ -73,7 +74,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 	var buf bytes.Buffer
 	selectCmd := fmt.Sprintf("%s %s",
 		config.Conf.General.SelectCmd, strings.Join(options, " "))
-	err = run(selectCmd, strings.NewReader(text), &buf)
+	err = runner.Run(selectCmd, strings.NewReader(text), &buf)
 	if err != nil {
 		return nil, nil
 	}
@@ -143,7 +144,7 @@ func selectFile(options []string, tag string) (snippetFile string, err error) {
 	var buf bytes.Buffer
 	selectCmd := fmt.Sprintf("%s %s",
 		config.Conf.General.SelectCmd, strings.Join(options, " "))
-	err = run(selectCmd, strings.NewReader(text), &buf)
+	err = runner.Run(selectCmd, strings.NewReader(text), &buf)
 	if err != nil {
 		return snippetFile, nil
 	}

--- a/dialog/dynamic_options.go
+++ b/dialog/dynamic_options.go
@@ -1,0 +1,32 @@
+package dialog
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	runner "github.com/knqyf263/pet/cmd/runner"
+)
+
+// DynamicOptions run a command, split and returns an array of strings. It expect to
+// receive command substitions.
+//
+// Example:
+//
+//	DynamicOptions("$(fd -tf --hidden --no-ignore --max-depth=1 .)")
+func DynamicOptions(what string) ([]string, error) {
+	if what[:2] != "$(" || what[len(what)-1] != ')' {
+		return nil, fmt.Errorf("no evaluated command found: %v", what)
+	}
+
+	var w bytes.Buffer
+	err := runner.Run(what[2:len(what)-1], os.Stdin, &w)
+	if err != nil {
+		log.Fatal(what)
+		return nil, err
+	}
+
+	return strings.Split(strings.TrimSpace(w.String()), "\n"), nil
+}

--- a/dialog/dynamic_options_test.go
+++ b/dialog/dynamic_options_test.go
@@ -1,0 +1,30 @@
+package dialog_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/knqyf263/pet/dialog"
+)
+
+const nameOfThisFile = "eval_test.go"
+
+func TestEvaluator(t *testing.T) {
+	param := "$(ls)"
+
+	e, err := dialog.DynamicOptions(param)
+	if err != nil {
+		t.Log(err)
+		t.FailNow()
+	}
+
+	if len(e) == 0 {
+		t.Log("Expected at least one result, but got none.")
+		t.FailNow()
+	}
+
+	if !slices.Contains(e, nameOfThisFile) {
+		t.Log("it should have the current file in this path")
+		t.FailNow()
+	}
+}

--- a/dialog/view.go
+++ b/dialog/view.go
@@ -134,7 +134,26 @@ func GenerateParamsLayout(params [][2]string, command string) {
 		r := regexp.MustCompile(parameterMultipleValueRegex)
 		matches := r.FindAllStringSubmatch(parameterValue, -1)
 
-		if len(matches) > 0 {
+		if len(matches) == 1 {
+			// Extract the default values and generate multiple params view
+			// using early evaluation context
+			matchedGroup := matches[0][1]
+			parameter := matchedGroup[2 : len(matchedGroup)-2]
+
+			options, err := DynamicOptions(parameter)
+			if err != nil {
+				// fallback to default evaluation (raw)
+				options = []string{parameter}
+			}
+
+			generateMultipleParameterView(
+				g, parameterKey, options, []int{
+					leftX,
+					(maxY / 4) + (idx+1)*layoutStep,
+					rightX,
+					(maxY / 4) + 2 + (idx+1)*layoutStep},
+				true)
+		} else if len(matches) > 0 {
 			// Extract the default values and generate multiple params view
 			parameters := []string{}
 			for _, p := range matches {


### PR DESCRIPTION
*Description of changes:*

Add support to early eval an option item.

```
# same as used to be
cat <file=$(ls)>

# same as used to be
cat <file=|__|_$(ls)_|>

# same as used to be
cat <file=|_opt1_|_opt2_|>

# ADDED
cat <file=|_$(ls)_|>
```

In this case (last scenario), it'll execute `ls` using `cmd/runner/Run` function (which keeps record of folder and shell to use), before create the gui, therefore, allowing user to just select one of the output elements.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
