### PR TITLE
Add pet in Terra repo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Download rpm package from [the releases page](https://github.com/knqyf263/pet/re
 ```
 sudo rpm -ivh https://github.com/knqyf263/pet/releases/download/v0.3.0/pet_0.3.0_linux_amd64.rpm
 ```
-Also available on the [Terra Repository](https://terra.fyralabs.com/) (3rd party)
+Also available on the [Terra repository](https://terra.fyralabs.com/) (3rd party)
 ```
 sudo dnf install pet
 ```

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Download rpm package from [the releases page](https://github.com/knqyf263/pet/re
 ```
 sudo rpm -ivh https://github.com/knqyf263/pet/releases/download/v0.3.0/pet_0.3.0_linux_amd64.rpm
 ```
-Also available on the [Terra repository](https://terra.fyralabs.com/) (3rd party)
+Also available on the [Terra repository](https://terra.fyralabs.com/) (3rd party) for Fedora/Fedora-based distros
 ```
 sudo dnf install pet
 ```

--- a/README.md
+++ b/README.md
@@ -467,10 +467,14 @@ brew unlink pet && brew uninstall pet
 brew install knqyf263/pet/pet
 ```
 
-## RedHat, CentOS
+## Fedora, RedHat, CentOS
 Download rpm package from [the releases page](https://github.com/knqyf263/pet/releases)
 ```
 sudo rpm -ivh https://github.com/knqyf263/pet/releases/download/v0.3.0/pet_0.3.0_linux_amd64.rpm
+```
+Also available on the [Terra Repository](https://terra.fyralabs.com/) (3rd party)
+```
+sudo dnf install pet
 ```
 
 ## Debian, Ubuntu


### PR DESCRIPTION
*Description of changes:*

I recently packaged pet into the Terra repository, a 3rd party repository for Fedora/Fedora based distributions, so I have added this to your README.

I also added Fedora in the RPM download guide, along with RedHat/CentOS, as I feel it should be there.

Link to package PR: https://github.com/terrapkg/packages/pull/2127