### PR TITLE
Filter snippets by tag -> pet list -t $tag #329

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -30,7 +30,7 @@ func list(cmd *cobra.Command, args []string) error {
 	}
 
 	if config.Flag.FilterTag != "" {
-		snippets.FilterByTags(strings.Split(config.Flag.FilterTag, ","))
+		snippets.Snippets = snippets.FilterByTags(strings.Split(config.Flag.FilterTag, ","))
 	}
 
 	col := config.Conf.General.Column

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,6 +29,10 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.Flag.FilterTag != "" {
+		snippets.FilterByTags(strings.Split(config.Flag.FilterTag, ","))
+	}
+
 	col := config.Conf.General.Column
 	if col == 0 {
 		col = column
@@ -82,4 +86,5 @@ func init() {
 	RootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVarP(&config.Flag.OneLine, "oneline", "", false,
 		`Display snippets in one line`)
+	listCmd.Flags().StringVar(&config.Flag.FilterTag, "t", "", "list by specified tags as comma separated values")
 }

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -164,6 +164,35 @@ func (snippets *Snippets) Order() {
 	}
 }
 
+// FilterByTags filters snippets by tags.
+func (snippets *Snippets) FilterByTags(tags []string) {
+	var filteredSnippets []SnippetInfo
+
+	for _, snippet := range snippets.Snippets {
+		if len(snippet.Tag) == 0 {
+			continue
+		}
+
+		for _, tag := range tags {
+			if contains(snippet.Tag, tag) {
+				filteredSnippets = append(filteredSnippets, snippet)
+				break
+			}
+		}
+	}
+
+	snippets.Snippets = filteredSnippets
+}
+
+func contains(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
 func (snippets *Snippets) reverse() {
 	for i, j := 0, len(snippets.Snippets)-1; i < j; i, j = i+1, j-1 {
 		snippets.Snippets[i], snippets.Snippets[j] = snippets.Snippets[j], snippets.Snippets[i]

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 
 	"github.com/knqyf263/pet/config"
@@ -165,32 +166,21 @@ func (snippets *Snippets) Order() {
 }
 
 // FilterByTags filters snippets by tags.
-func (snippets *Snippets) FilterByTags(tags []string) {
-	var filteredSnippets []SnippetInfo
-
+func (snippets *Snippets) FilterByTags(tags []string) (filteredSnippets []SnippetInfo) {
 	for _, snippet := range snippets.Snippets {
 		if len(snippet.Tag) == 0 {
 			continue
 		}
 
 		for _, tag := range tags {
-			if contains(snippet.Tag, tag) {
+			if slices.Contains(snippet.Tag, tag) {
 				filteredSnippets = append(filteredSnippets, snippet)
 				break
 			}
 		}
 	}
 
-	snippets.Snippets = filteredSnippets
-}
-
-func contains(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
-			return true
-		}
-	}
-	return false
+	return filteredSnippets
 }
 
 func (snippets *Snippets) reverse() {

--- a/snippet/snippet_test.go
+++ b/snippet/snippet_test.go
@@ -303,3 +303,41 @@ func TestSaveWithMultipleSnippetFiles(t *testing.T) {
 `
 	assert.Equal(t, want, string(data))
 }
+
+func TestFilterByTags(t *testing.T) {
+	snippets := &Snippets{
+		Snippets: []SnippetInfo{
+			{
+				Description: "Test snippet",
+				Command:     "echo 'Hello, World!'",
+				Tag:         []string{"test"},
+				Output:      "Hello, World!",
+			},
+			{
+				Description: "Test snippet 2",
+				Command:     "echo 'Hello, World 2!'",
+				Tag:         []string{"test", "test2"},
+				Output:      "Hello, World 2!",
+			},
+			{
+				Description: "Test snippet 3",
+				Command:     "echo 'Hello, World 3!'",
+				Tag:         []string{"test", "test3"},
+				Output:      "Hello, World 3!",
+			},
+		},
+	}
+
+	// Filter by a single tag
+	filteredSnippets := snippets.FilterByTags([]string{"test"})
+	assert.Len(t, filteredSnippets, 3)
+	assert.Equal(t, "Test snippet", filteredSnippets[0].Description)
+	assert.Equal(t, "Test snippet 2", filteredSnippets[1].Description)
+
+	// Filter by multiple tags
+	filteredSnippets = snippets.FilterByTags([]string{"test", "test2"})
+	assert.Len(t, filteredSnippets, 3)
+	assert.Equal(t, "Test snippet", filteredSnippets[0].Description)
+	assert.Equal(t, "Test snippet 2", filteredSnippets[1].Description)
+	assert.Equal(t, "Test snippet 3", filteredSnippets[2].Description)
+}


### PR DESCRIPTION
*Issue #, if available:*
#329
*Description of changes:*

Added support of tag filtering on list command


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
