### PR TITLE
docs: add example of fzf history use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ The values in this case would be :Hello \<subject=\|\_<mark>John</mark>\_\|\|\_<
 # Examples
 Some examples are shown below.
 
+## Allow to register from history when using fzf
+
+Just export this to your `.bashrc` or `.zshrc` file. This will show your history
+as default (when using fzf) and it also binds the `alt+s` key combination
+to allow you to search and save some previous used command command.
+
+```
+export FZF_CTRL_R_OPTS="
+  --reverse
+  --cycle
+  --info=right
+  --color header:italic
+  --header 'alt+s (pet new)'
+  --preview 'echo {}' --preview-window down:3:hidden:wrap 
+  --bind '?:toggle-preview'
+  --bind 'alt-s:execute(pet new --tag {2..})+abort'"
+```
+
 ## Register the previous command easily
 By adding the following config to `.bashrc` or `.zshrc`, you can easily register the previous command.
 

--- a/README.md
+++ b/README.md
@@ -108,24 +108,6 @@ The values in this case would be :Hello \<subject=\|\_<mark>John</mark>\_\|\|\_<
 # Examples
 Some examples are shown below.
 
-## Allow to register from history when using fzf
-
-Just export this to your `.bashrc` or `.zshrc` file. This will show your history
-as default (when using fzf) and it also binds the `alt+s` key combination
-to allow you to search and save some previous used command command.
-
-```
-export FZF_CTRL_R_OPTS="
-  --reverse
-  --cycle
-  --info=right
-  --color header:italic
-  --header 'alt+s (pet new)'
-  --preview 'echo {}' --preview-window down:3:hidden:wrap 
-  --bind '?:toggle-preview'
-  --bind 'alt-s:execute(pet new --tag {2..})+abort'"
-```
-
 ## Register the previous command easily
 By adding the following config to `.bashrc` or `.zshrc`, you can easily register the previous command.
 
@@ -196,6 +178,24 @@ https://github.com/otms61/fish-pet
 By using `pbcopy` on OS X, you can copy snippets to clipboard.
 
 <img src="doc/pet06.gif" width="700">
+
+## Allow to register from history when using fzf
+
+Just export this to your `.bashrc` or `.zshrc` file. This will show your history
+as default (when using fzf) and it also binds the `alt+s` key combination
+to allow you to search and save some previous used command command.
+
+```
+export FZF_CTRL_R_OPTS="
+  --reverse
+  --cycle
+  --info=right
+  --color header:italic
+  --header 'alt+s (pet new)'
+  --preview 'echo {}' --preview-window down:3:hidden:wrap 
+  --bind '?:toggle-preview'
+  --bind 'alt-s:execute(pet new --tag {2..})+abort'"
+```
 
 # Features
 


### PR DESCRIPTION
*Description of changes:*

To pick and create a new command from history
using fzf key combinations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.