### PR TITLE
FEATURE: flag to suppress the command output

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,7 +33,9 @@ func execute(cmd *cobra.Command, args []string) (err error) {
 	command := strings.Join(commands, "; ")
 
 	// Show final command before executing it
-	fmt.Printf("> %s\n", command)
+	if !flag.Quiet {
+		fmt.Printf("> %s\n", command)
+	}
 
 	return run(command, os.Stdin, os.Stdout)
 }
@@ -46,4 +48,6 @@ func init() {
 		`Initial value for query`)
 	execCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
 		`Filter tag`)
+	execCmd.Flags().BoolVarP(&config.Flag.Quiet, "silent", "s", false,
+		`Supress the command output`)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,7 @@ type FlagConfig struct {
 	Tag          bool
 	UseMultiLine bool
 	UseEditor    bool
+	Quiet		 bool
 }
 
 // Load loads a config toml


### PR DESCRIPTION
## Description
Sometimes, we want to get the output of the `pet exec` into a shell variable. like:
```bash
FOO=$(pet exec)
echo $FOO
```
but actually it's not possible, because actually we do not have flags to supress the command output after a `exec`

https://github.com/knqyf263/pet/blob/1c390631f298ddef3e457c5294cba236fd093e18/cmd/exec.go#L36

## Proposed Solution
I would like to use `-q` as `--quiet` but as in this project we adopted `--query` with `-q`, looks better to use `--silent` and `-s` to enable this feature.
```bash
FOO=$(pet exec -s)
echo $FOO
```

## Terms
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.