### PR TITLE
feat(exec) Filter by tags in exec cmd

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -23,13 +23,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 	// Filter the snippets by specified tag if any
 	if 0 < len(tag) {
 		var filteredSnippets snippet.Snippets
-		for _, snippet := range snippets.Snippets {
-			for _, t := range snippet.Tag {
-				if tag == t {
-					filteredSnippets.Snippets = append(filteredSnippets.Snippets, snippet)
-				}
-			}
-		}
+		filteredSnippets.Snippets = snippets.FilterByTags(strings.Split(tag, ","))
 		snippets = filteredSnippets
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reuse of the FilterByTags method and adding the ability to filter by tags, not just a single tag, when using the 'exec' command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
