### PR TITLE
feat: add flag to select command without parameter insertion dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ bindkey '^s' pet-select
 
 function _pet_move_cursor_to_next_parameter() {
     match="$(echo "$BUFFER" | perl -nle 'print $& if /<.*?>/')"
-    if [ ! -z "$match" ]; then
+    if [ -n "$match" ]; then
       default="$(echo "$match" | perl -nle 'print $& if /(?<==).*(?=>)/')"
       match_len=${#match}
       default_len=${#default}

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ bind -x '"\C-x\C-r": pet-select'
 
 function _pet_move_cursor_to_next_parameter() {
   match="$(echo "$READLINE_LINE" | perl -nle 'print $& if /<.*?>/')"
-  if [ ! -z "$match" ]; then
+  if [ -n "$match" ]; then
     default="$(echo "$match" | perl -nle 'print $& if /(?<==).*(?=>)/')"
     match_len=${#match}
     default_len=${#default}

--- a/cmd/clip.go
+++ b/cmd/clip.go
@@ -26,7 +26,7 @@ func clip(cmd *cobra.Command, args []string) (err error) {
 		options = append(options, fmt.Sprintf("--query %s", flag.Query))
 	}
 
-	commands, err := filter(options, flag.FilterTag)
+	commands, err := filter(options, flag.FilterTag, flag.Raw)
 	if err != nil {
 		return err
 	}
@@ -39,6 +39,8 @@ func clip(cmd *cobra.Command, args []string) (err error) {
 
 func init() {
 	RootCmd.AddCommand(clipCmd)
+	clipCmd.Flags().BoolVarP(&config.Flag.Raw, "raw", "", false,
+		`Output raw command without entering parameter dialog`)
 	clipCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
 		`Initial value for query`)
 	clipCmd.Flags().BoolVarP(&config.Flag.Command, "command", "", false,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -27,7 +27,7 @@ func _execute(in io.ReadCloser, out io.Writer) (err error) {
 		options = append(options, fmt.Sprintf("--query %s", shellescape.Quote(flag.Query)))
 	}
 
-	commands, err := filter(options, flag.FilterTag)
+	commands, err := filter(options, flag.FilterTag, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,7 +25,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 	if flag.Query != "" {
 		options = append(options, fmt.Sprintf("--query %s", shellescape.Quote(flag.Query)))
 	}
-	commands, err := filter(options, flag.FilterTag)
+	commands, err := filter(options, flag.FilterTag, flag.Raw)
 	if err != nil {
 		return err
 	}
@@ -39,6 +39,8 @@ func search(cmd *cobra.Command, args []string) (err error) {
 
 func init() {
 	RootCmd.AddCommand(searchCmd)
+	searchCmd.Flags().BoolVarP(&config.Flag.Raw, "raw", "", false,
+		`Output raw command without entering parameter dialog`)
 	searchCmd.Flags().BoolVarP(&config.Flag.Color, "color", "", false,
 		`Enable colorized output (only fzf)`)
 	searchCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -14,7 +14,7 @@ import (
 	"github.com/knqyf263/pet/snippet"
 )
 
-func filter(options []string, tag string) (commands []string, err error) {
+func filter(options []string, tag string, raw bool) (commands []string, err error) {
 	var snippets snippet.Snippets
 	if err := snippets.Load(true); err != nil {
 		return commands, fmt.Errorf("load snippet failed: %v", err)
@@ -76,7 +76,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 	var params [][2]string
 
 	// If only one line is selected, search for params in the command
-	if len(lines) == 1 {
+	if len(lines) == 1 && !raw {
 		snippetInfo := snippetTexts[lines[0]]
 		params = dialog.SearchForParams(snippetInfo.Command)
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,8 @@ type FlagConfig struct {
 	Tag          bool
 	UseMultiLine bool
 	UseEditor    bool
-	Silent		 bool
+	Silent       bool
+	Raw          bool
 }
 
 // Load loads a config toml


### PR DESCRIPTION
Covers #264, #358

## Description

Add a `--raw` flag to `pet search` and `pet clip` that causes pet to skip the parameter insertion dialog and output the command as is, with parameters unexpanded.

With this option, we can delegate parameter insertion to the shell, which would allow for more featureful editing, e.g. tab-completion, syntax highlighting, etc.

The README now has examples for implementing this in bash and zsh. Here is how it looks in bash:


https://github.com/user-attachments/assets/3e859844-75f1-4286-a149-068fa8c4334d



> [!NOTE]
> This is inspired by how [marker](https://github.com/pindexis/marker) handles the parameter insertion.
